### PR TITLE
(PRE-15) Add help option to --schema

### DIFF
--- a/api/documentation/preview-help.md
+++ b/api/documentation/preview-help.md
@@ -22,7 +22,7 @@ puppet preview [
     [--baseline_environment <ENV-NAME> | --be <ENV-NAME>]
     --preview_environment <ENV-NAME> | --pe <ENV-NAME>
     <NODE-NAME>
-  ]|[--schema catalog|catalog_delta]
+  ]|[--schema catalog|catalog_delta|help]
    |[-h|--help]
    |[-V|--version]
 ```
@@ -146,9 +146,10 @@ Note that all settings such as 'log_level' affects both compilations.
   This specifies for which node the preview should produce output. The node must
   have previously requested a catalog from the master to make its facts available.
   
-* --schema catalog | catalog_delta
-  Outputs the json-schema for the puppet catalog, or for the catalog_delta. Can not be
-  combined with any other option.
+* --schema catalog | catalog_delta | help
+  Outputs the json-schema for the puppet catalog, or for the catalog_delta. The option
+  'help' will display the semantics of the catalog-diff schema. Can not be combined with
+  any other option.
   
 * --skip_tags
   Ignores comparison of tags, catalogs are considered equal/compliant if they only

--- a/lib/puppet/application/preview.rb
+++ b/lib/puppet/application/preview.rb
@@ -40,10 +40,10 @@ class Puppet::Application::Preview < Puppet::Application
   end
 
   option("--schema CATALOG") do |arg|
-    if %w{catalog catalog_delta}.include?(arg)
+    if %w{catalog catalog_delta help}.include?(arg)
       options[:schema] = arg.to_sym
     else
-      raise "The --schema option only accepts 'catalog' or 'catalog_delta' as arguments.\nRun 'puppet preview --help' for more details"
+      raise "The --schema option only accepts 'catalog', 'catalog_delta', or 'help' as arguments.\nRun 'puppet preview --help' for more details"
     end
   end
 
@@ -92,9 +92,12 @@ class Puppet::Application::Preview < Puppet::Application
       if options[:schema] == "catalog"
         catalog_path = ::File.expand_path("../../../../api/schemas/catalog.json", __FILE__)
         display_file(catalog_path)
-      else
+      elsif options[:schema] == "catalog_delta"
         delta_path = ::File.expand_path("../../../../api/schemas/catalog-delta.json", __FILE__)
         display_file(delta_path)
+      else
+        help_path = ::File.expand_path("../../../../api/documentation/catalog-delta.md", __FILE__)
+        display_file(help_path)
       end
     else
       unless options[:node]


### PR DESCRIPTION
Add a help option to the --schema flag. If preview is run with
'--schema help' it will output the contents of catalog-delta.md
to provide the user help with the semantics of the catalog-diff
schema that is produced by preview.
