### PR TITLE
(PRE-19) Add ability to suppress number/string differences

### DIFF
--- a/lib/puppet/application/preview.rb
+++ b/lib/puppet/application/preview.rb
@@ -49,6 +49,8 @@ class Puppet::Application::Preview < Puppet::Application
 
   option("--skip_tags")
 
+  option("--ignore_string_numeric_diff")
+
   option("--trusted") do |arg|
     unless Puppet.features.root?
       raise "The --trusted option is only available when running as root"
@@ -290,7 +292,7 @@ class Puppet::Application::Preview < Puppet::Application
   end
 
   def catalog_diff(timestamp, baseline_hash, preview_hash)
-    delta = CatalogDelta.new(baseline_hash['data'], preview_hash['data'], options[:skip_tags], options[:verbose_diff])
+    delta = CatalogDelta.new(baseline_hash['data'], preview_hash['data'], options[:skip_tags], options[:ignore_string_numeric_diff], options[:verbose_diff])
     result = delta.to_hash
 
     # Finish result by supplying information that is not in the catalogs and not produced by the diff utility
@@ -356,6 +358,7 @@ Catalog:
   Versions......: #{delta[:version_equal] ? 'equal' : 'different' }
   Preview.......: #{delta[:preview_equal] ? 'equal' : delta[:preview_compliant] ? 'compliant' : 'different'}
   Tags..........: #{delta[:tags_ignored] ? 'ignored' : 'compared'}
+  String/Numeric: #{delta[:string_numeric_diff_ignored] ? 'numerically compared' : 'different'}
 
 Resources:
   Baseline......: #{delta[:baseline_resource_count]}

--- a/spec/unit/catalog_delta_model_spec.rb
+++ b/spec/unit/catalog_delta_model_spec.rb
@@ -38,7 +38,8 @@ describe 'CatalogDelta' do
             'subscribe' => %w(a b c),
             'notify' => %w(a b c),
             'tags' => %w(a b c),
-            'hash' => { 'a' => 'A', 'b' => [1,2]}
+            'hash' => { 'a' => 'A', 'b' => [1,2]},
+            'mol' => "42"
           }
         }
       ],
@@ -67,20 +68,20 @@ describe 'CatalogDelta' do
   let(:preview_hash) { deep_clone(baseline_hash)}
 
   it 'reports that tags are skipped' do
-    delta = CatalogDelta.new(baseline_hash, preview_hash, true, false)
+    delta = CatalogDelta.new(baseline_hash, preview_hash, true, false, false)
     expect(delta.tags_ignored?).to be(true)
   end
 
   it 'reports version_equal' do
-    delta = CatalogDelta.new(baseline_hash, preview_hash, true, false)
+    delta = CatalogDelta.new(baseline_hash, preview_hash, true, false, false)
     expect(delta.version_equal?).to be(true)
-    delta = CatalogDelta.new(baseline_hash, preview_hash.merge!('version' => 1427456348), true, false)
+    delta = CatalogDelta.new(baseline_hash, preview_hash.merge!('version' => 1427456348), true, false, false)
     expect(delta.version_equal?).to be(false)
   end
 
   it 'version inequality has no impact on preview equality or compliance' do
-    delta = CatalogDelta.new(baseline_hash, preview_hash, true, false)
-    delta = CatalogDelta.new(baseline_hash, preview_hash.merge!('version' => 1427456348), true, false)
+    delta = CatalogDelta.new(baseline_hash, preview_hash, true, false, false)
+    delta = CatalogDelta.new(baseline_hash, preview_hash.merge!('version' => 1427456348), true, false, false)
     expect(delta.preview_equal?).to be(true)
     expect(delta.preview_compliant?).to be(true)
   end
@@ -88,7 +89,7 @@ describe 'CatalogDelta' do
   it 'reports missing resource' do
     pv = preview_hash
     pv['resources'].pop
-    delta = CatalogDelta.new(baseline_hash, pv, true, false)
+    delta = CatalogDelta.new(baseline_hash, pv, true, false, false)
     expect(delta.missing_resource_count).to eq(1)
     expect(delta.missing_resources).to contain_exactly(be_a(Resource))
     expect(delta.missing_resources[0].type).to eq('File')
@@ -106,7 +107,7 @@ describe 'CatalogDelta' do
         'line' => 3,
       }
     )
-    delta = CatalogDelta.new(baseline_hash, pv, true, false)
+    delta = CatalogDelta.new(baseline_hash, pv, true, false, false)
     expect(delta.added_resource_count).to eq(1)
     expect(delta.added_resources).to contain_exactly(be_a(Resource))
     expect(delta.added_resources[0].type).to eq('File')
@@ -122,7 +123,7 @@ describe 'CatalogDelta' do
         'file' => '/etc/puppet/environments/production/manifests/site.pp',
         'line' => 1,
       }
-    delta = CatalogDelta.new(baseline_hash, pv, true, false)
+    delta = CatalogDelta.new(baseline_hash, pv, true, false, false)
     expect(delta.conflicting_resource_count).to eq(1)
     expect(delta.conflicting_resources).to contain_exactly(be_a(ResourceConflict))
     conflict = delta.conflicting_resources[0]
@@ -150,7 +151,7 @@ describe 'CatalogDelta' do
         'mode' => '0775'
       }
     }
-    delta = CatalogDelta.new(baseline_hash, pv, true, false)
+    delta = CatalogDelta.new(baseline_hash, pv, true, false, false)
     expect(delta.conflicting_resource_count).to eq(1)
     expect(delta.conflicting_resources).to contain_exactly(be_a(ResourceConflict))
     conflict = delta.conflicting_resources[0]
@@ -177,7 +178,7 @@ describe 'CatalogDelta' do
         'ensure' => 'absent',
       }
     }
-    delta = CatalogDelta.new(baseline_hash, pv, true, false)
+    delta = CatalogDelta.new(baseline_hash, pv, true, false, false)
     expect(delta.conflicting_resource_count).to eq(1)
     expect(delta.conflicting_resources).to contain_exactly(be_a(ResourceConflict))
     conflict = delta.conflicting_resources[0]
@@ -196,7 +197,7 @@ describe 'CatalogDelta' do
   it 'reports missing edges' do
     pv = preview_hash
     pv['edges'].pop
-    delta = CatalogDelta.new(baseline_hash, pv, true, false)
+    delta = CatalogDelta.new(baseline_hash, pv, true, false, false)
     expect(delta.missing_edge_count).to eq(1)
     expect(delta.missing_edges).to contain_exactly(be_a(Edge))
     edge = delta.missing_edges[0]
@@ -212,7 +213,7 @@ describe 'CatalogDelta' do
         'target' => 'Notify[roses are red]'
       }
     )
-    delta = CatalogDelta.new(baseline_hash, pv, true, false)
+    delta = CatalogDelta.new(baseline_hash, pv, true, false, false)
     expect(delta.baseline_edge_count).to eq(1)
     expect(delta.preview_edge_count).to eq(2)
     expect(delta.added_edge_count).to eq(1)
@@ -233,7 +234,7 @@ describe 'CatalogDelta' do
         'line' => 3,
       }
     )
-    delta = CatalogDelta.new(baseline_hash, pv, true, false)
+    delta = CatalogDelta.new(baseline_hash, pv, true, false, false)
     expect(delta.preview_equal?).to be(false)
     expect(delta.preview_compliant?).to be(true)
   end
@@ -241,7 +242,7 @@ describe 'CatalogDelta' do
   it 'considers missing resources to be different and not compliant' do
     pv = preview_hash
     pv['resources'].pop()
-    delta = CatalogDelta.new(baseline_hash, pv, true, false)
+    delta = CatalogDelta.new(baseline_hash, pv, true, false, false)
     expect(delta.preview_equal?).to be(false)
     expect(delta.preview_compliant?).to be(false)
   end
@@ -254,7 +255,7 @@ describe 'CatalogDelta' do
         'target' => 'Notify[roses are red]'
       }
     )
-    delta = CatalogDelta.new(baseline_hash, pv, true, false)
+    delta = CatalogDelta.new(baseline_hash, pv, true, false, false)
     expect(delta.preview_equal?).to be(false)
     expect(delta.preview_compliant?).to be(true)
   end
@@ -262,7 +263,7 @@ describe 'CatalogDelta' do
   it 'considers missing edges to be different and not compliant' do
     pv = preview_hash
     pv['edges'].pop()
-    delta = CatalogDelta.new(baseline_hash, pv, true, false)
+    delta = CatalogDelta.new(baseline_hash, pv, true, false, false)
     expect(delta.preview_equal?).to be(false)
     expect(delta.preview_compliant?).to be(false)
   end
@@ -281,7 +282,7 @@ describe 'CatalogDelta' do
         'mode' => '0775'
       }
     }
-    delta = CatalogDelta.new(baseline_hash, pv, true, false)
+    delta = CatalogDelta.new(baseline_hash, pv, true, false, false)
     expect(delta.preview_equal?).to be(false)
     expect(delta.preview_compliant?).to be(true)
   end
@@ -289,7 +290,7 @@ describe 'CatalogDelta' do
   it 'considers adding a value to an array attribute to be different but compliant' do
     pv = preview_hash
     pv['resources'][1]['parameters']['array'].push(4)
-    delta = CatalogDelta.new(baseline_hash, pv, true, false)
+    delta = CatalogDelta.new(baseline_hash, pv, true, false, false)
     expect(delta.preview_equal?).to be(false)
     expect(delta.preview_compliant?).to be(true)
   end
@@ -297,7 +298,7 @@ describe 'CatalogDelta' do
   it 'considers adding a value to a hash attribute to be different but compliant' do
     pv = preview_hash
     pv['resources'][1]['parameters']['hash']['c'] = 3
-    delta = CatalogDelta.new(baseline_hash, pv, true, false)
+    delta = CatalogDelta.new(baseline_hash, pv, true, false, false)
     expect(delta.preview_equal?).to be(false)
     expect(delta.preview_compliant?).to be(true)
   end
@@ -305,7 +306,7 @@ describe 'CatalogDelta' do
   it 'considers changing an element of a hash attribute to a compliant element to be different but compliant' do
     pv = preview_hash
     pv['resources'][1]['parameters']['hash']['b']= [2,1]
-    delta = CatalogDelta.new(baseline_hash, pv, true, false)
+    delta = CatalogDelta.new(baseline_hash, pv, true, false, false)
     expect(delta.preview_equal?).to be(false)
     expect(delta.preview_compliant?).to be(true)
   end
@@ -313,7 +314,7 @@ describe 'CatalogDelta' do
   it 'considers array attributes with the same content but differnet order to be different but compliant' do
     pv = preview_hash
     pv['resources'][1]['parameters']['array'] = %w(c b a c)
-    delta = CatalogDelta.new(baseline_hash, pv, true, false)
+    delta = CatalogDelta.new(baseline_hash, pv, true, false, false)
     expect(delta.preview_equal?).to be(false)
     expect(delta.preview_compliant?).to be(true)
   end
@@ -323,7 +324,7 @@ describe 'CatalogDelta' do
     params = pv['resources'][1]['parameters']
     %w(before after subscribe notify tags).each do |attr|
       params[attr] = %w(c b a c a)
-      delta = CatalogDelta.new(baseline_hash, pv, true, false)
+      delta = CatalogDelta.new(baseline_hash, pv, true, false, false)
       expect(delta.preview_equal?).to be(true)
     end
   end
@@ -331,7 +332,7 @@ describe 'CatalogDelta' do
   it 'considers array attributes not named before, after, subscribe, notify, or tags to use List semantics' do
     pv = preview_hash
     pv['resources'][1]['parameters']['array'] = %w(c b a)
-    delta = CatalogDelta.new(baseline_hash, pv, true, false)
+    delta = CatalogDelta.new(baseline_hash, pv, true, false, false)
     expect(delta.preview_equal?).to be(false)
     expect(delta.preview_compliant?).to be(false)
   end
@@ -339,7 +340,7 @@ describe 'CatalogDelta' do
   it 'considers array attributes with less content to be non compliant' do
     pv = preview_hash
     pv['resources'][1]['parameters']['array'] = %w(c b)
-    delta = CatalogDelta.new(baseline_hash, pv, true, false)
+    delta = CatalogDelta.new(baseline_hash, pv, true, false, false)
     expect(delta.preview_equal?).to be(false)
     expect(delta.preview_compliant?).to be(false)
   end
@@ -355,10 +356,36 @@ describe 'CatalogDelta' do
         'line' => 3,
       }
     )
-    delta = CatalogDelta.new(baseline_hash, pv, true, false)
+    delta = CatalogDelta.new(baseline_hash, pv, true, false, false)
     expect(delta.added_resources[0].attributes).to be_nil
-    delta = CatalogDelta.new(baseline_hash, pv, true, true)
+    delta = CatalogDelta.new(baseline_hash, pv, true, false, true)
     expect(delta.added_resources[0].attributes).to be_a(Array)
+  end
+
+  it 'ignores or detects string/int differences depending on ignore_string_numeric_diff flag' do
+    pv = preview_hash
+    pv['resources'][1]['parameters']['mol'] = 42
+    delta = CatalogDelta.new(baseline_hash, pv, true, true, false)
+    expect(delta.preview_equal?).to be(true)
+    expect(delta.preview_compliant?).to be(true)
+    expect(delta.string_numeric_diff_ignored?).to be(true)
+    delta = CatalogDelta.new(baseline_hash, pv, true, false, false)
+    expect(delta.preview_equal?).to be(false)
+    expect(delta.preview_compliant?).to be(false)
+    expect(delta.string_numeric_diff_ignored?).to be(false)
+    expect(delta.conflicting_resource_count).to eq(1)
+    expect(delta.conflicting_resources).to contain_exactly(be_a(ResourceConflict))
+    conflict = delta.conflicting_resources[0]
+    expect(conflict.type).to eq('File')
+    expect(conflict.title).to eq('/tmp/bartest')
+    expect(conflict.missing_attribute_count).to eq(0)
+    expect(conflict.added_attribute_count).to eq(0)
+    expect(conflict.conflicting_attribute_count).to eq(1)
+    expect(conflict.conflicting_attributes).to contain_exactly(be_a(AttributeConflict))
+    attr = conflict.conflicting_attributes[0]
+    expect(attr.name).to eq('mol')
+    expect(attr.baseline_value).to eq('42')
+    expect(attr.preview_value).to eq(42)
   end
 end
 end


### PR DESCRIPTION
The 3x parser uses strings as the internal representation of numbers.
This will potentially create a lot of noice when creating deltas
between 3x and 4x compiled code. This commit adds the boolean option
--ignore_string_numeric_diff. When used, the CatalogDelta producer will
detect and ignore differences between numbers in the preview model
that are equal to their string counterbart in the baseline if the
string is converted to a numeric.
