### PR TITLE
(maint) Update metadata and remove apache license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,6 @@
+This Module is only available for users of Puppet Enterprise with a valid Software License Agreement 
+for Puppet Enterprise.  This Module is not available for users of Puppet software under an open source license.
+
+By downloading this Module, you agree that you have a valid Software License Agreement with Puppet Labs for 
+Puppet Enterprise and you further agree that your use of this Module is governed by the terms of that 
+Software License Agreement.

--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ The help for the catalog-delta is viewable on the command line with:
 
 The content of this model is:
 
-Copyright (c) 2015 Puppet Labs, LLC Licensed under Puppet Labs Commercial.
+Copyright (c) 2015 Puppet Labs, LLC Licensed under Puppet Labs Enterprise.

--- a/lib/puppet_x/puppetlabs/preview/api/documentation/preview-help.md
+++ b/lib/puppet_x/puppetlabs/preview/api/documentation/preview-help.md
@@ -236,5 +236,5 @@ Henrik Lindberg, Puppet Labs
 
 COPYRIGHT
 ---------
-Copyright (c) 2015 Puppet Labs, LLC Licensed under Puppet Labs Commercial.
+Copyright (c) 2015 Puppet Labs, LLC Licensed under Puppet Labs Enterprise.
 

--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,13 @@
   "project_page": "https://github.com/puppetlabs/puppetlabs-preview",
   "issues_url": "https://tickets.puppetlabs.com/browse/PRE",
   "tags": [
-    "migration"
+    "migration",
+    "preview",
+    "refactoring",
+    "compliance",
+    "catalog",
+    "diff",
+    "delta"
   ],
   "operatingsystem_support": [
   


### PR DESCRIPTION
In order to prepare for the initial release of preview, update the
metadata so that is is accurate, and remove the Apache license
since this is not an open source module (and thus is licensed under
Puppet Labs Commercial).
