### PR TITLE
(PRE-22) Ensure that attribute that are Sets can be single values

### DIFF
--- a/lib/puppet_x/puppetlabs/migration/catalog_delta_model.rb
+++ b/lib/puppet_x/puppetlabs/migration/catalog_delta_model.rb
@@ -151,7 +151,10 @@ module PuppetX::Puppetlabs::Migration::CatalogDeltaModel
     # @param value [Object] the attribute value
     def initialize(name, value)
       @name = assert_type(String, name)
-      value = Set.new(assert_type(Array, value, [])) if SET_ATTRIBUTES.include?(name)
+      if SET_ATTRIBUTES.include?(name)
+        value = [value] unless value.is_a?(Array)
+        value = Set.new(value)
+      end
       @value = value
     end
   end

--- a/lib/puppet_x/puppetlabs/preview/api/documentation/catalog-delta.md
+++ b/lib/puppet_x/puppetlabs/preview/api/documentation/catalog-delta.md
@@ -231,7 +231,9 @@ The following attributes are treated as sets:
 * `notify`
 * `tags`
 
-That is, the order of elements never matters, and duplicate entries are ignored.
+That is, the order of elements never matters, and duplicate entries are ignored. When
+one of these attributes have a single value, it will be treated as a set containing that
+value.
 
 For other array attributes, the exact content must be present for the parameter to
 be considered equal. For compliance, the preview array must contain the same

--- a/spec/unit/catalog_delta_model_spec.rb
+++ b/spec/unit/catalog_delta_model_spec.rb
@@ -44,6 +44,18 @@ describe 'CatalogDelta' do
             'hash' => { 'a' => 'A', 'b' => [1,2]},
             'mol' => "42"
           }
+        },
+        {
+          'type' => 'File',
+          'title' => '/tmp/fumtest',
+          'tags' => ['file', 'class'],
+          'file' => '/etc/puppet/environments/production/manifests/site.pp',
+          'line' => 3,
+          'exported' => false,
+          'parameters' => {
+            'before' => 'a',
+            'after' => ['a']
+          }
         }
       ],
       'edges' => [
@@ -118,7 +130,7 @@ describe 'CatalogDelta' do
     expect(delta.missing_resource_count).to eq(1)
     expect(delta.missing_resources).to contain_exactly(be_a(Resource))
     expect(delta.missing_resources[0].type).to eq('File')
-    expect(delta.missing_resources[0].title).to eq('/tmp/bartest')
+    expect(delta.missing_resources[0].title).to eq('/tmp/fumtest')
     JSON::Validator.validate!(catalog_delta_schema, JSON.dump(delta.to_hash))
   end
 
@@ -127,7 +139,7 @@ describe 'CatalogDelta' do
     pv['resources'].push(
       {
         'type' => 'File',
-        'title' => '/tmp/fumtest',
+        'title' => '/tmp/baztest',
         'tags' => ['file', 'class'],
         'file' => '/etc/puppet/environments/production/manifests/site.pp',
         'line' => 4,
@@ -137,7 +149,7 @@ describe 'CatalogDelta' do
     expect(delta.added_resource_count).to eq(1)
     expect(delta.added_resources).to contain_exactly(be_a(Resource))
     expect(delta.added_resources[0].type).to eq('File')
-    expect(delta.added_resources[0].title).to eq('/tmp/fumtest')
+    expect(delta.added_resources[0].title).to eq('/tmp/baztest')
     JSON::Validator.validate!(catalog_delta_schema, JSON.dump(delta.to_hash))
   end
 
@@ -260,7 +272,7 @@ describe 'CatalogDelta' do
     pv['resources'].push(
       {
         'type' => 'File',
-        'title' => '/tmp/fumtest',
+        'title' => '/tmp/baztest',
         'tags' => ['file', 'class'],
         'file' => '/etc/puppet/environments/production/manifests/site.pp',
         'line' => 4,
@@ -371,6 +383,17 @@ describe 'CatalogDelta' do
     end
   end
 
+  it 'allows variables that have Set semantics to be strings' do
+    pv = preview_hash
+    pv['resources'][2]['parameters'] =  {
+        'before' => ['a'],
+        'after' => 'a'
+    }
+    delta = CatalogDelta.new(baseline_hash, pv, options, timestamp)
+    expect(delta.preview_equal?).to be(true)
+    expect(delta.preview_compliant?).to be(true)
+  end
+
   it 'considers array attributes not named before, after, subscribe, notify, or tags to use List semantics' do
     pv = preview_hash
     pv['resources'][1]['parameters']['array'] = %w(c b a)
@@ -394,7 +417,7 @@ describe 'CatalogDelta' do
     pv['resources'].push(
       {
         'type' => 'File',
-        'title' => '/tmp/fumtest',
+        'title' => '/tmp/baztest',
         'tags' => ['file', 'class'],
         'file' => '/etc/puppet/environments/production/manifests/site.pp',
         'line' => 4,


### PR DESCRIPTION
The attributes before, after, subscribe, notify, and tags use
Set semantics when comparing baseline and preview values. Before
this commit it was assumed that the values to be compared originated
from arrays. This is now changed so that single values are also
accepted (and will be converted into one element arrays) and compared
using Set semantics.
