### PR TITLE
(PRE-14) Add spec test that validates the catalog diff with json schema

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ group :development, :unit_tests do
   gem 'rspec-puppet',            :require => false
   gem 'mocha',                   :require => false
   gem 'rubocop',                 :require => false
+  gem 'json-schema',             :require => false
 end
 
 group :development, :unit_tests, :test do

--- a/lib/puppet/application/preview.rb
+++ b/lib/puppet/application/preview.rb
@@ -312,23 +312,7 @@ class Puppet::Application::Preview < Puppet::Application
   end
 
   def catalog_diff(timestamp, baseline_hash, preview_hash)
-    delta = CatalogDelta.new(
-      baseline_hash['data'], 
-      preview_hash['data'], 
-      options[:skip_tags], 
-      options[:migration_checker] && !options[:diff_string_numeric],
-      options[:verbose_diff])
-    result = delta.to_hash
-
-    # Finish result by supplying information that is not in the catalogs and not produced by the diff utility
-    #
-    result[:produced_by]      = 'puppet preview 3.8.0'
-    result[:timestamp]        = timestamp
-    result[:baseline_catalog] = options[:baseline_catalog]
-    result[:preview_catalog]  = options[:preview_catalog]
-    result[:node_name]        = options[:node]
-
-    result
+    CatalogDelta.new(baseline_hash['data'], preview_hash['data'], options, timestamp).to_hash
   end
 
   def display_file(file)

--- a/lib/puppet_x/puppetlabs/preview/api/schemas/catalog-delta.json
+++ b/lib/puppet_x/puppetlabs/preview/api/schemas/catalog-delta.json
@@ -8,7 +8,7 @@
             "type": "string",
             "description": "The name of the node for which the baseline and preview catalogs were compiled"
         },
-        "time": {
+        "timestamp": {
             "type": "string",
             "description": "When preview run began. In ISO 8601 format with 9 characters second-fragment"
         },
@@ -52,6 +52,10 @@
             "type": "integer",
             "description": "number of resources in preview but not in baseline"
         },
+        "equal_resource_count": {
+            "type": "integer",
+            "description": "number of resources in both preview and baseline"
+        },
         "missing_resource_count": {
             "type": "integer",
             "description": "number of resources in baseline but not in preview"
@@ -67,6 +71,10 @@
         "missing_edge_count": {
             "type": "integer",
             "description": "number of edges in baseline but not in preview"
+        },
+        "equal_attribute_count": {
+            "type": "integer",
+            "description": "total number of resource attributes in both preview and baseline"
         },
         "added_attribute_count": {
             "type": "integer",
@@ -120,19 +128,25 @@
         "tags_ignored": {
             "type": "boolean",
             "description": "This delta was produced with tags being ignored"
+        },
+        "string_numeric_diff_ignored": {
+            "type": "boolean",
+            "description": "This delta was produced considering strings and numbers equal if their numeric representation is the same"
         }
     },
     "required": [
         "node_name",
-        "time",
+        "timestamp",
         "produced_by",
         "baseline_env",
         "preview_env",
+        "equal_resource_count",
         "added_resource_count",
         "missing_resource_count",
         "conflicting_resource_count",
         "added_edge_count",
         "missing_edge_count",
+        "equal_attribute_count",
         "added_attribute_count",
         "missing_attribute_count",
         "conflicting_attribute_count",
@@ -151,102 +165,89 @@
             "required": ["file"]
         },
         "attribute": {
-            "allOf": [
-                {
-                    "properties": {
-                        "diff_id": {"type": "integer"},
-                        "name": {"type": "string"},
-                        "value": {"type": "any"}
-                    },
-                    "required": ["name", "value"]
-                }
-            ],
+            "properties": {
+                "diff_id": {"type": "integer"},
+                "name": {"type": "string"},
+                "value": {}
+            },
+            "required": ["name", "value"],
             "additionalProperties": false
         },
         "conflicting_attribute": {
-            "allOf": [
-                {
-                    "properties": {
-                        "diff_id": {"type": "integer"},
-                        "name": {"type": "string"},
-                        "baseline_value": {"type": "any"},
-                        "preview_value": {"type": "any"},
-                        "compliant": {
-                            "type": "boolean",
-                            "description": "Values different, but preview contains baseline"
-                        }
-                    },
-                    "required": ["name", "baseline_value", "preview_value"]
+            "type": "object",
+            "properties": {
+                "diff_id": {"type": "integer"},
+                "name": {"type": "string"},
+                "baseline_value": {},
+                "preview_value": {},
+                "compliant": {
+                    "type": "boolean",
+                    "description": "Values different, but preview contains baseline"
                 }
-            ],
+            },
+            "required": ["name", "baseline_value", "preview_value"],
             "additionalProperties": false
         },
         "resource": {
-            "allOf": [
-                {
-                    "properties": {
-                        "diff_id": {"type": "integer"},
-                        "location": {
-                            "$ref": "#/definitions/location",
-                            "description": "The location as reported in the preview"
-                        },
-                        "type": {"type": "string"},
-                        "title": {"type": "string"},
-                        "attributes": {
-                            "type": "array",
-                            "items": {"$ref": "#/definitions/attribute"}
-                        }
-                    },
-                    "required": ["type", "title"]
+            "type": "object",
+            "properties": {
+                "diff_id": {"type": "integer"},
+                "location": {
+                    "$ref": "#/definitions/location",
+                    "description": "The location as reported in the preview"
+                },
+                "type": {"type": "string"},
+                "title": {"type": "string"},
+                "attributes": {
+                    "type": "array",
+                    "items": {"$ref": "#/definitions/attribute"}
                 }
-            ],
+            },
+            "required": ["type", "title"],
             "additionalProperties": false
         },
         "conflicting_resource": {
-            "allOf": [
-                {
-                    "properties": {
-                        "baseline_location": {
-                            "$ref": "#/definitions/location",
-                            "description": "The location as reported in the baseline"
-                        },
-                        "preview_location": {
-                            "$ref": "#/definitions/location",
-                            "description": "The location as reported in the preview"
-                        },
-                        "diff_id": {"type": "integer"},
-                        "type": {"type": "string"},
-                        "title": {"type": "string"},
-                        "equal_attribute_count": {"type": "integer"},
-                        "missing_attribute_count": {"type": "integer"},
-                        "added_attribute_count": {"type": "integer"},
-                        "conflicting_attribute_count": {"type": "integer"},
-                        "missing_attributes": {
-                            "type": "array",
-                            "items": {"$ref": "#/definitions/attribute"}
-                        },
-                        "added_attributes": {
-                            "type": "array",
-                            "items": {"$ref": "#/definitions/attribute"}
-                        },
-                        "conflicting_attributes": {
-                            "type": "array",
-                            "items": {"$ref": "#/definitions/conflicting_attribute"}
-                        },
-                        "compliant": {
-                            "type": "boolean",
-                            "description": "Has attributes that differ, but all are compliant"
-                        }
-                    },
-                    "required": [
-                        "type",
-                        "title",
-                        "equal_attributes_count",
-                        "missing_attributes_count",
-                        "added_attributes_count",
-                        "conflicting_attributes_count"
-                    ]
+            "type": "object",
+            "properties": {
+                "baseline_location": {
+                    "$ref": "#/definitions/location",
+                    "description": "The location as reported in the baseline"
+                },
+                "preview_location": {
+                    "$ref": "#/definitions/location",
+                    "description": "The location as reported in the preview"
+                },
+                "diff_id": {"type": "integer"},
+                "type": {"type": "string"},
+                "title": {"type": "string"},
+                "equal_attribute_count": {"type": "integer"},
+                "missing_attribute_count": {"type": "integer"},
+                "added_attribute_count": {"type": "integer"},
+                "conflicting_attribute_count": {"type": "integer"},
+                "missing_attributes": {
+                    "type": "array",
+                    "items": {"$ref": "#/definitions/attribute"}
+                },
+                "added_attributes": {
+                    "type": "array",
+                    "items": {"$ref": "#/definitions/attribute"}
+                },
+                "conflicting_attributes": {
+                    "type": "array",
+                    "items": {"$ref": "#/definitions/conflicting_attribute"}
+                },
+                "compliant": {
+                    "type": "boolean",
+                    "description": "Has attributes that differ, but all are compliant"
                 }
+            },
+            "required": [
+                "type",
+                "title",
+                "equal_attribute_count",
+                "missing_attribute_count",
+                "added_attribute_count",
+                "conflicting_attribute_count"
             ],
             "additionalProperties": false
         },

--- a/spec/unit/catalog_delta_model_spec.rb
+++ b/spec/unit/catalog_delta_model_spec.rb
@@ -2,9 +2,12 @@ require 'spec_helper'
 require 'puppet'
 require 'puppet/pops'
 require 'puppet_x/puppetlabs/preview'
+require 'json'
+require 'json-schema'
 
 module PuppetX::Puppetlabs::Migration::CatalogDeltaModel
 describe 'CatalogDelta' do
+
   let(:baseline_hash) do
     {
       'tags' => ['settings'],
@@ -67,33 +70,56 @@ describe 'CatalogDelta' do
 
   let(:preview_hash) { deep_clone(baseline_hash)}
 
+  let(:timestamp) { Time.now.iso8601(9) }
+  let(:options) { {
+    :node => 'test.example.com',
+    :baseline_catalog => '/path/to/baseline/catalog',
+    :preview_catalog => '/path/to/preview/catalog',
+    :migration_checker => false,
+    :diff_string_numeric => false,
+    :skip_tags => true,
+    :verbose_diff => false
+  } }
+
+  let(:schema_dir) { 'lib/puppet_x/puppetlabs/preview/api/schemas' }
+  let(:json_meta_schema) { JSON.parse(File.read(File.join(schema_dir, 'json-meta-schema.json'))) }
+  let(:catalog_delta_schema) { JSON.parse(File.read(File.join(schema_dir, 'catalog-delta.json'))) }
+
+  it 'has a valid JSON schema' do
+    JSON::Validator.validate!(json_meta_schema, catalog_delta_schema)
+  end
+
   it 'reports that tags are skipped' do
-    delta = CatalogDelta.new(baseline_hash, preview_hash, true, false, false)
+    delta = CatalogDelta.new(baseline_hash, preview_hash, options, timestamp)
     expect(delta.tags_ignored?).to be(true)
   end
 
   it 'reports version_equal' do
-    delta = CatalogDelta.new(baseline_hash, preview_hash, true, false, false)
+    delta = CatalogDelta.new(baseline_hash, preview_hash, options, timestamp)
     expect(delta.version_equal?).to be(true)
-    delta = CatalogDelta.new(baseline_hash, preview_hash.merge!('version' => 1427456348), true, false, false)
+    JSON::Validator.validate!(catalog_delta_schema, JSON.dump(delta.to_hash))
+
+    delta = CatalogDelta.new(baseline_hash, preview_hash.merge!('version' => 1427456348), options, timestamp)
     expect(delta.version_equal?).to be(false)
+    JSON::Validator.validate!(catalog_delta_schema, JSON.dump(delta.to_hash))
   end
 
   it 'version inequality has no impact on preview equality or compliance' do
-    delta = CatalogDelta.new(baseline_hash, preview_hash, true, false, false)
-    delta = CatalogDelta.new(baseline_hash, preview_hash.merge!('version' => 1427456348), true, false, false)
+    delta = CatalogDelta.new(baseline_hash, preview_hash.merge!('version' => 1427456348), options, timestamp)
     expect(delta.preview_equal?).to be(true)
     expect(delta.preview_compliant?).to be(true)
+    JSON::Validator.validate!(catalog_delta_schema, JSON.dump(delta.to_hash))
   end
 
   it 'reports missing resource' do
     pv = preview_hash
     pv['resources'].pop
-    delta = CatalogDelta.new(baseline_hash, pv, true, false, false)
+    delta = CatalogDelta.new(baseline_hash, pv, options, timestamp)
     expect(delta.missing_resource_count).to eq(1)
     expect(delta.missing_resources).to contain_exactly(be_a(Resource))
     expect(delta.missing_resources[0].type).to eq('File')
     expect(delta.missing_resources[0].title).to eq('/tmp/bartest')
+    JSON::Validator.validate!(catalog_delta_schema, JSON.dump(delta.to_hash))
   end
 
   it 'reports added resource' do
@@ -104,14 +130,15 @@ describe 'CatalogDelta' do
         'title' => '/tmp/fumtest',
         'tags' => ['file', 'class'],
         'file' => '/etc/puppet/environments/production/manifests/site.pp',
-        'line' => 3,
+        'line' => 4,
       }
     )
-    delta = CatalogDelta.new(baseline_hash, pv, true, false, false)
+    delta = CatalogDelta.new(baseline_hash, pv, options, timestamp)
     expect(delta.added_resource_count).to eq(1)
     expect(delta.added_resources).to contain_exactly(be_a(Resource))
     expect(delta.added_resources[0].type).to eq('File')
     expect(delta.added_resources[0].title).to eq('/tmp/fumtest')
+    JSON::Validator.validate!(catalog_delta_schema, JSON.dump(delta.to_hash))
   end
 
   it 'reports conflicting resource when preview is missing an attribute' do
@@ -123,7 +150,7 @@ describe 'CatalogDelta' do
         'file' => '/etc/puppet/environments/production/manifests/site.pp',
         'line' => 1,
       }
-    delta = CatalogDelta.new(baseline_hash, pv, true, false, false)
+    delta = CatalogDelta.new(baseline_hash, pv, options, timestamp)
     expect(delta.conflicting_resource_count).to eq(1)
     expect(delta.conflicting_resources).to contain_exactly(be_a(ResourceConflict))
     conflict = delta.conflicting_resources[0]
@@ -135,6 +162,7 @@ describe 'CatalogDelta' do
     expect(conflict.missing_attributes).to contain_exactly(be_a(Attribute))
     attr = conflict.missing_attributes[0]
     expect(attr.name).to eq('ensure')
+    JSON::Validator.validate!(catalog_delta_schema, JSON.dump(delta.to_hash))
   end
 
   it 'reports conflicting resource when preview is adding an attribute' do
@@ -151,7 +179,7 @@ describe 'CatalogDelta' do
         'mode' => '0775'
       }
     }
-    delta = CatalogDelta.new(baseline_hash, pv, true, false, false)
+    delta = CatalogDelta.new(baseline_hash, pv, options, timestamp)
     expect(delta.conflicting_resource_count).to eq(1)
     expect(delta.conflicting_resources).to contain_exactly(be_a(ResourceConflict))
     conflict = delta.conflicting_resources[0]
@@ -163,6 +191,7 @@ describe 'CatalogDelta' do
     expect(conflict.added_attributes).to contain_exactly(be_a(Attribute))
     attr = conflict.added_attributes[0]
     expect(attr.name).to eq('mode')
+    JSON::Validator.validate!(catalog_delta_schema, JSON.dump(delta.to_hash))
   end
 
   it 'reports conflicting resource when there is a conflicting attribute' do
@@ -178,7 +207,7 @@ describe 'CatalogDelta' do
         'ensure' => 'absent',
       }
     }
-    delta = CatalogDelta.new(baseline_hash, pv, true, false, false)
+    delta = CatalogDelta.new(baseline_hash, pv, options, timestamp)
     expect(delta.conflicting_resource_count).to eq(1)
     expect(delta.conflicting_resources).to contain_exactly(be_a(ResourceConflict))
     conflict = delta.conflicting_resources[0]
@@ -192,17 +221,19 @@ describe 'CatalogDelta' do
     expect(attr.name).to eq('ensure')
     expect(attr.baseline_value).to eq('present')
     expect(attr.preview_value).to eq('absent')
+    JSON::Validator.validate!(catalog_delta_schema, JSON.dump(delta.to_hash))
   end
 
   it 'reports missing edges' do
     pv = preview_hash
     pv['edges'].pop
-    delta = CatalogDelta.new(baseline_hash, pv, true, false, false)
+    delta = CatalogDelta.new(baseline_hash, pv, options, timestamp)
     expect(delta.missing_edge_count).to eq(1)
     expect(delta.missing_edges).to contain_exactly(be_a(Edge))
     edge = delta.missing_edges[0]
     expect(edge.source).to eq('Class[main]')
     expect(edge.target).to eq('File[/tmp/footest]')
+    JSON::Validator.validate!(catalog_delta_schema, JSON.dump(delta.to_hash))
   end
 
   it 'reports added edges' do
@@ -213,7 +244,7 @@ describe 'CatalogDelta' do
         'target' => 'Notify[roses are red]'
       }
     )
-    delta = CatalogDelta.new(baseline_hash, pv, true, false, false)
+    delta = CatalogDelta.new(baseline_hash, pv, options, timestamp)
     expect(delta.baseline_edge_count).to eq(1)
     expect(delta.preview_edge_count).to eq(2)
     expect(delta.added_edge_count).to eq(1)
@@ -221,6 +252,7 @@ describe 'CatalogDelta' do
     edge = delta.added_edges[0]
     expect(edge.source).to eq('Class[main]')
     expect(edge.target).to eq('Notify[roses are red]')
+    JSON::Validator.validate!(catalog_delta_schema, JSON.dump(delta.to_hash))
   end
 
   it 'considers added resources to be different but compliant' do
@@ -231,20 +263,22 @@ describe 'CatalogDelta' do
         'title' => '/tmp/fumtest',
         'tags' => ['file', 'class'],
         'file' => '/etc/puppet/environments/production/manifests/site.pp',
-        'line' => 3,
+        'line' => 4,
       }
     )
-    delta = CatalogDelta.new(baseline_hash, pv, true, false, false)
+    delta = CatalogDelta.new(baseline_hash, pv, options, timestamp)
     expect(delta.preview_equal?).to be(false)
     expect(delta.preview_compliant?).to be(true)
+    JSON::Validator.validate!(catalog_delta_schema, JSON.dump(delta.to_hash))
   end
 
   it 'considers missing resources to be different and not compliant' do
     pv = preview_hash
     pv['resources'].pop()
-    delta = CatalogDelta.new(baseline_hash, pv, true, false, false)
+    delta = CatalogDelta.new(baseline_hash, pv, options, timestamp)
     expect(delta.preview_equal?).to be(false)
     expect(delta.preview_compliant?).to be(false)
+    JSON::Validator.validate!(catalog_delta_schema, JSON.dump(delta.to_hash))
   end
 
   it 'considers added edges to be different but compliant' do
@@ -255,17 +289,19 @@ describe 'CatalogDelta' do
         'target' => 'Notify[roses are red]'
       }
     )
-    delta = CatalogDelta.new(baseline_hash, pv, true, false, false)
+    delta = CatalogDelta.new(baseline_hash, pv, options, timestamp)
     expect(delta.preview_equal?).to be(false)
     expect(delta.preview_compliant?).to be(true)
+    JSON::Validator.validate!(catalog_delta_schema, JSON.dump(delta.to_hash))
   end
 
   it 'considers missing edges to be different and not compliant' do
     pv = preview_hash
     pv['edges'].pop()
-    delta = CatalogDelta.new(baseline_hash, pv, true, false, false)
+    delta = CatalogDelta.new(baseline_hash, pv, options, timestamp)
     expect(delta.preview_equal?).to be(false)
     expect(delta.preview_compliant?).to be(false)
+    JSON::Validator.validate!(catalog_delta_schema, JSON.dump(delta.to_hash))
   end
 
   it 'considers adding attributes to be different but compliant' do
@@ -282,41 +318,46 @@ describe 'CatalogDelta' do
         'mode' => '0775'
       }
     }
-    delta = CatalogDelta.new(baseline_hash, pv, true, false, false)
+    delta = CatalogDelta.new(baseline_hash, pv, options, timestamp)
     expect(delta.preview_equal?).to be(false)
     expect(delta.preview_compliant?).to be(true)
+    JSON::Validator.validate!(catalog_delta_schema, JSON.dump(delta.to_hash))
   end
 
   it 'considers adding a value to an array attribute to be different but compliant' do
     pv = preview_hash
     pv['resources'][1]['parameters']['array'].push(4)
-    delta = CatalogDelta.new(baseline_hash, pv, true, false, false)
+    delta = CatalogDelta.new(baseline_hash, pv, options, timestamp)
     expect(delta.preview_equal?).to be(false)
     expect(delta.preview_compliant?).to be(true)
+    JSON::Validator.validate!(catalog_delta_schema, JSON.dump(delta.to_hash))
   end
 
   it 'considers adding a value to a hash attribute to be different but compliant' do
     pv = preview_hash
     pv['resources'][1]['parameters']['hash']['c'] = 3
-    delta = CatalogDelta.new(baseline_hash, pv, true, false, false)
+    delta = CatalogDelta.new(baseline_hash, pv, options, timestamp)
     expect(delta.preview_equal?).to be(false)
     expect(delta.preview_compliant?).to be(true)
+    JSON::Validator.validate!(catalog_delta_schema, JSON.dump(delta.to_hash))
   end
 
   it 'considers changing an element of a hash attribute to a compliant element to be different but compliant' do
     pv = preview_hash
     pv['resources'][1]['parameters']['hash']['b']= [2,1]
-    delta = CatalogDelta.new(baseline_hash, pv, true, false, false)
+    delta = CatalogDelta.new(baseline_hash, pv, options, timestamp)
     expect(delta.preview_equal?).to be(false)
     expect(delta.preview_compliant?).to be(true)
+    JSON::Validator.validate!(catalog_delta_schema, JSON.dump(delta.to_hash))
   end
 
   it 'considers array attributes with the same content but differnet order to be different but compliant' do
     pv = preview_hash
     pv['resources'][1]['parameters']['array'] = %w(c b a c)
-    delta = CatalogDelta.new(baseline_hash, pv, true, false, false)
+    delta = CatalogDelta.new(baseline_hash, pv, options, timestamp)
     expect(delta.preview_equal?).to be(false)
     expect(delta.preview_compliant?).to be(true)
+    JSON::Validator.validate!(catalog_delta_schema, JSON.dump(delta.to_hash))
   end
 
   it 'considers array attributes named before, after, subscribe, notify, or tags to use Set semantics' do
@@ -324,25 +365,28 @@ describe 'CatalogDelta' do
     params = pv['resources'][1]['parameters']
     %w(before after subscribe notify tags).each do |attr|
       params[attr] = %w(c b a c a)
-      delta = CatalogDelta.new(baseline_hash, pv, true, false, false)
+      delta = CatalogDelta.new(baseline_hash, pv, options, timestamp)
       expect(delta.preview_equal?).to be(true)
+      JSON::Validator.validate!(catalog_delta_schema, JSON.dump(delta.to_hash))
     end
   end
 
   it 'considers array attributes not named before, after, subscribe, notify, or tags to use List semantics' do
     pv = preview_hash
     pv['resources'][1]['parameters']['array'] = %w(c b a)
-    delta = CatalogDelta.new(baseline_hash, pv, true, false, false)
+    delta = CatalogDelta.new(baseline_hash, pv, options, timestamp)
     expect(delta.preview_equal?).to be(false)
     expect(delta.preview_compliant?).to be(false)
+    JSON::Validator.validate!(catalog_delta_schema, JSON.dump(delta.to_hash))
   end
 
   it 'considers array attributes with less content to be non compliant' do
     pv = preview_hash
     pv['resources'][1]['parameters']['array'] = %w(c b)
-    delta = CatalogDelta.new(baseline_hash, pv, true, false, false)
+    delta = CatalogDelta.new(baseline_hash, pv, options, timestamp)
     expect(delta.preview_equal?).to be(false)
     expect(delta.preview_compliant?).to be(false)
+    JSON::Validator.validate!(catalog_delta_schema, JSON.dump(delta.to_hash))
   end
 
   it 'does not include resource attributes in delta unless verbose is given' do
@@ -353,23 +397,28 @@ describe 'CatalogDelta' do
         'title' => '/tmp/fumtest',
         'tags' => ['file', 'class'],
         'file' => '/etc/puppet/environments/production/manifests/site.pp',
-        'line' => 3,
+        'line' => 4,
       }
     )
-    delta = CatalogDelta.new(baseline_hash, pv, true, false, false)
+    delta = CatalogDelta.new(baseline_hash, pv, options, timestamp)
     expect(delta.added_resources[0].attributes).to be_nil
-    delta = CatalogDelta.new(baseline_hash, pv, true, false, true)
+    JSON::Validator.validate!(catalog_delta_schema, JSON.dump(delta.to_hash))
+
+    delta = CatalogDelta.new(baseline_hash, pv, options.merge(:verbose_diff => true), timestamp)
     expect(delta.added_resources[0].attributes).to be_a(Array)
+    JSON::Validator.validate!(catalog_delta_schema, JSON.dump(delta.to_hash))
   end
 
-  it 'ignores or detects string/int differences depending on ignore_string_numeric_diff flag' do
+  it 'ignores or detects string/int differences depending on migration_checker and diff_string_numeric flag' do
     pv = preview_hash
     pv['resources'][1]['parameters']['mol'] = 42
-    delta = CatalogDelta.new(baseline_hash, pv, true, true, false)
+    delta = CatalogDelta.new(baseline_hash, pv, options.merge(:migration_checker => true, :diff_string_numeric => false), timestamp)
     expect(delta.preview_equal?).to be(true)
     expect(delta.preview_compliant?).to be(true)
     expect(delta.string_numeric_diff_ignored?).to be(true)
-    delta = CatalogDelta.new(baseline_hash, pv, true, false, false)
+    JSON::Validator.validate!(catalog_delta_schema, JSON.dump(delta.to_hash))
+
+    delta = CatalogDelta.new(baseline_hash, pv, options.merge(:migration_checker => true, :diff_string_numeric => true), timestamp)
     expect(delta.preview_equal?).to be(false)
     expect(delta.preview_compliant?).to be(false)
     expect(delta.string_numeric_diff_ignored?).to be(false)
@@ -386,6 +435,17 @@ describe 'CatalogDelta' do
     expect(attr.name).to eq('mol')
     expect(attr.baseline_value).to eq('42')
     expect(attr.preview_value).to eq(42)
+    JSON::Validator.validate!(catalog_delta_schema, JSON.dump(delta.to_hash))
+
+    delta = CatalogDelta.new(baseline_hash, pv, options.merge(:migration_checker => false, :diff_string_numeric => true), timestamp)
+    expect(delta.preview_equal?).to be(false)
+    expect(delta.preview_compliant?).to be(false)
+    expect(delta.string_numeric_diff_ignored?).to be(false)
+
+    delta = CatalogDelta.new(baseline_hash, pv, options.merge(:migration_checker => false, :diff_string_numeric => false), timestamp)
+    expect(delta.preview_equal?).to be(false)
+    expect(delta.preview_compliant?).to be(false)
+    expect(delta.string_numeric_diff_ignored?).to be(false)
   end
 end
 end


### PR DESCRIPTION
This commit adds the tests needed to validate the json schema for
the CatalogDelta. It also altered all current tests using CatalogDelta
instances so that the instance is validated using the schema.

The CatalogDelta was modified so that the method to_hash now produces
a Hash that, when JSON generated, is a valid instance of the catalog
delta json schema. This made the delta easier to validate and it
also vouches for cleaner code since the hash doesn't need to be
modified with additional attributes after the delta is created.

In fact, there's no real reason why the preview command should use
a hash everywhere instead of the proper CatalogDelta object. The
only time the hash is really needed is when the user requests JSON
output. This commit did not change this however, but I suggest that
change to become a separate issue.
