### PR TITLE
(PUP-4241) add file checks to puppet preview integration tests

### DIFF
--- a/spec/integration/nodesets/debian-8-x86_64.yaml
+++ b/spec/integration/nodesets/debian-8-x86_64.yaml
@@ -1,0 +1,14 @@
+---
+HOSTS:
+  master:
+    roles:
+    - master
+    - agent
+    platform: debian-jessie-x86_64
+    hypervisor: vcloud
+    template: debian-8-x86_64
+CONFIG:
+  datastore: instance0
+  resourcepool: delivery/Quality Assurance/FOSS/Dynamic
+  folder: Delivery/Quality Assurance/FOSS/Dynamic
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/


### PR DESCRIPTION
this change tests the various log files that are output from puppet
preview.  They should all, always be there, no matter the exit code, but
are tested against the successful run with exit code of 0.

this change also changes "default" to master, to be more definitive
and adds a debian configuration file

This change removes --migrate option from a single test to ensure it's
not required and fixes the test for upstream changes to stderr features.
