### PR TITLE
(maint) update integration helper for pe

### DIFF
--- a/spec/integration/nodesets/pe/centos-7-64mda.yaml
+++ b/spec/integration/nodesets/pe/centos-7-64mda.yaml
@@ -1,0 +1,25 @@
+--
+HOSTS:
+  centos-7-x86_64:
+    roles:
+    - master
+    - dashboard
+    - database
+    - agent
+    - default
+    platform: el-7-x86_64
+    template: centos-7-x86_64
+    hypervisor: vcloud
+  centos-7-x86_64-agent:
+    roles:
+    - agent
+    platform: el-7-x86_64
+    template: centos-7-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/

--- a/spec/integration/nodesets/pe/redhat-6-64mda
+++ b/spec/integration/nodesets/pe/redhat-6-64mda
@@ -1,0 +1,22 @@
+HOSTS:
+  redhat-6-x86_64:
+    roles:
+      - master
+      - dashboard
+      - database
+      - agent
+    platform: el-6-x86_64
+    template: redhat-6-x86_64
+    hypervisor: vcloud
+  redhat-6-x86_64-agent:
+    roles:
+      - agent
+    platform: el-6-x86_64
+    template: redhat-6-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic

--- a/spec/integration/nodesets/pe/redhat-7-64mda
+++ b/spec/integration/nodesets/pe/redhat-7-64mda
@@ -1,0 +1,25 @@
+---
+HOSTS:
+  redhat-7-x86_64:
+    roles:
+    - master
+    - dashboard
+    - database
+    - agent
+    - default
+    platform: el-7-x86_64
+    template: redhat-7-x86_64
+    hypervisor: vcloud
+  redhat-7-x86_64-agent:
+    roles:
+    - agent
+    platform: el-7-x86_64
+    template: redhat-7-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/

--- a/spec/integration/nodesets/redhat-7-x86_64.yaml
+++ b/spec/integration/nodesets/redhat-7-x86_64.yaml
@@ -11,3 +11,4 @@ CONFIG:
   resourcepool: delivery/Quality Assurance/FOSS/Dynamic
   folder: Delivery/Quality Assurance/FOSS/Dynamic
   pooling_api: http://vmpooler.delivery.puppetlabs.net/
+  type: foss


### PR DESCRIPTION
Changes to ensure integration setup works for both foss and PE.
Remove hard-coded path to moduledir, this is done correctly when
options[:type] is set to foss or the default of pe.
Add two example pe host config files to ease setup outside of CI
fix the foss host config file to specify type.

This won't work until the CI job is updated to specify a PE 3.8 build,
and SPEC_FORGE is unset (or the module is on the staging forge)

i ran with: pe_dist_dir="http://enterprise.delivery.puppetlabs.net/3.8/ci-ready/" BEAKER_destroy=no BEAKER_setfile=spec/integration/nodesets/pe/redhat-7-64mda bundle exec rspec spec/integration/
