### PR TITLE
(PRE-23) Return structured facts for the future parser

### DIFF
--- a/lib/puppet/application/preview.rb
+++ b/lib/puppet/application/preview.rb
@@ -441,6 +441,17 @@ Output:
       application_routes = routes['master'] # <-- This line is the actual change.
       Puppet::Indirector.configure_routes(application_routes) if application_routes
     end
+
+    # NOTE: PE 3.x ships PuppetDB 2.x and uses the v3 PuppetDB API endpoints.
+    # These return stringified, non-structured facts. However, many Future
+    # parser comparisions are type-sensitive. For example, a variable holding a
+    # stringified fact will fail to compare against an integer.
+    #
+    # So, if PuppetDB is in use, we swap in a copy of the 2.x terminus which
+    # uses the v4 API which returns properly structured and typed facts.
+    if Puppet::Node::Facts.indirection.terminus_class.to_s == 'puppetdb'
+      Puppet::Node::Facts.indirection.terminus_class = :diff_puppetdb
+    end
   end
 
   def setup_terminuses

--- a/lib/puppet/indirector/facts/diff_puppetdb.rb
+++ b/lib/puppet/indirector/facts/diff_puppetdb.rb
@@ -1,0 +1,155 @@
+require 'uri'
+require 'puppet/node/facts'
+require 'puppet/indirector/rest'
+require 'puppet/util/puppetdb'
+require 'json'
+require 'time'
+
+# A copy of the 2.x PuppetDB Facts terminus that performs find requests using
+# the v4 API so that non-stringified and structured facts are returned. This is
+# done because many comparisons executed by the future parser are
+# type-sensitive. Without fully-typed facts, a variable containing a
+# stringified fact (such as $::processorcount) will raise a fatal error when
+# compared against an integer.
+#
+# TODO: Remove once Puppet 4.0 or PuppetDB 3.0 are standard and backwards
+# compatibility with PE 3.x isn't required.
+class Puppet::Node::Facts::DiffPuppetdb < Puppet::Indirector::REST
+  include Puppet::Util::Puppetdb
+  include Puppet::Util::Puppetdb::CommandNames
+
+  def get_trusted_info(node)
+    trusted = Puppet.lookup(:trusted_information) do
+      Puppet::Context::TrustedInformation.local(node)
+    end
+    trusted.to_h
+  end
+
+  def save(request)
+    profile("facts#save", [:puppetdb, :facts, :save, request.key]) do
+      payload = profile("Encode facts command submission payload",
+                        [:puppetdb, :facts, :encode]) do
+        facts = request.instance.dup
+        facts.values = facts.strip_internal.dup
+
+        if ! Puppet::Util::Puppetdb.puppet3compat? || Puppet[:trusted_node_data]
+          facts.values[:trusted] = get_trusted_info(request.node)
+        end
+        {
+          "name" => facts.name,
+          "values" => facts.values,
+          # PDB-453: we call to_s to avoid a 'stack level too deep' error
+          # when we attempt to use ActiveSupport 2.3.16 on RHEL 5 with
+          # legacy storeconfigs.
+          "environment" => request.options[:environment] || request.environment.to_s,
+          "producer-timestamp" => request.options[:producer_timestamp] || Time.now.iso8601,
+        }
+      end
+
+      submit_command(request.key, payload, CommandReplaceFacts, 3)
+    end
+  end
+
+  def find(request)
+    profile("facts#find", [:puppetdb, :facts, :find, request.key]) do
+      begin
+        url = Puppet::Util::Puppetdb.url_path("/v4/nodes/#{CGI.escape(request.key)}/facts")
+        response = profile("Query for nodes facts: #{url}",
+                           [:puppetdb, :facts, :find, :query_nodes, request.key]) do
+          http_get(request, url, headers)
+        end
+        log_x_deprecation_header(response)
+
+        if response.is_a? Net::HTTPSuccess
+          profile("Parse fact query response (size: #{response.body.size})",
+                  [:puppetdb, :facts, :find, :parse_response, request.key]) do
+            result = JSON.parse(response.body)
+            # Note: the Inventory Service API appears to expect us to return nil here
+            # if the node isn't found.  However, PuppetDB returns an empty array in
+            # this case; for now we will just look for that condition and assume that
+            # it means that the node wasn't found, so we will return nil.  In the
+            # future we may want to improve the logic such that we can distinguish
+            # between the "node not found" and the "no facts for this node" cases.
+            if result.empty?
+              return nil
+            end
+            facts = result.inject({}) do |a,h|
+              a.merge(h['name'] => h['value'])
+            end
+            Puppet::Node::Facts.new(request.key, facts)
+          end
+        else
+          # Newline characters cause an HTTP error, so strip them
+          raise "[#{response.code} #{response.message}] #{response.body.gsub(/[\r\n]/, '')}"
+        end
+      rescue => e
+        raise Puppet::Error, "Failed to find facts from PuppetDB at #{self.class.server}:#{self.class.port}: #{e}"
+      end
+    end
+  end
+
+  # Search for nodes matching a set of fact constraints. The constraints are
+  # specified as a hash of the form:
+  #
+  # `{type.name.operator => value`
+  #
+  # The only accepted `type` is 'facts'.
+  #
+  # `name` must be the fact name to query against.
+  #
+  # `operator` may be one of {eq, ne, lt, gt, le, ge}, and will default to 'eq'
+  # if unspecified.
+  def search(request)
+    profile("facts#search", [:puppetdb, :facts, :search, request.key]) do
+      return [] unless request.options
+      operator_map = {
+        'eq' => '=',
+        'gt' => '>',
+        'lt' => '<',
+        'ge' => '>=',
+        'le' => '<=',
+      }
+      filters = request.options.sort.map do |key,value|
+        type, name, operator = key.to_s.split('.')
+        operator ||= 'eq'
+        raise Puppet::Error, "Fact search against keys of type '#{type}' is unsupported" unless type == 'facts'
+        if operator == 'ne'
+          ['not', ['=', ['fact', name], value]]
+        else
+          [operator_map[operator], ['fact', name], value]
+        end
+      end
+
+      query = ["and"] + filters
+      query_param = CGI.escape(query.to_json)
+
+      begin
+        url = Puppet::Util::Puppetdb.url_path("/v3/nodes?query=#{query_param}")
+        response = profile("Fact query request: #{URI.unescape(url)}",
+                           [:puppetdb, :facts, :search, :query_request, request.key]) do
+          http_get(request, url, headers)
+        end
+        log_x_deprecation_header(response)
+
+        if response.is_a? Net::HTTPSuccess
+          profile("Parse fact query response (size: #{response.body.size})",
+                  [:puppetdb, :facts, :search, :parse_query_response, request.key,]) do
+            JSON.parse(response.body).collect {|s| s["name"]}
+          end
+        else
+          # Newline characters cause an HTTP error, so strip them
+          raise "[#{response.code} #{response.message}] #{response.body.gsub(/[\r\n]/, '')}"
+        end
+      rescue => e
+        raise Puppet::Error, "Could not perform inventory search from PuppetDB at #{self.class.server}:#{self.class.port}: #{e}"
+      end
+    end
+  end
+
+  def headers
+    {
+      "Accept" => "application/json",
+      "Content-Type" => "application/x-www-form-urlencoded; charset=UTF-8",
+    }
+  end
+end


### PR DESCRIPTION
This pull request implements two changes:
- The `configure_indirector_routes` method is overridden to set up indirector routes using the `master` section of `routes.yaml`. This helps ensure the configuration of `puppet preview` will match `puppet master --compile` and Puppet Server.
- If the `terminus_class` for Facts is set to `PuppetDB`, a new `DiffPuppetDB` terminus is used. This terminus is a copy of the 2.3.2 PuppetDB Facts terminus that contains one change: the `find` method hits the v4 API instead of the v3 api.

Together, these changes ensure `puppet preview` gets structured and non-stringified facts. The use of non-stringified facts is important as future parser comparison operators are type sensitive. This commonly manifests in comparisons between stringified facts and integers which will fail when the future parser is in use.
