### PR TITLE
(maint) Use git protocol when cloning deps

### DIFF
--- a/spec/spec_helper_integration.rb
+++ b/spec/spec_helper_integration.rb
@@ -12,7 +12,7 @@ def build_giturl(project_name, git_fork = nil, git_server = nil)
   repo = (git_server == 'github.com') ?
     "#{git_fork}/#{project_name}.git" :
     "#{git_fork}-#{project_name}.git"
-    " git@#{git_server}:#{repo}"
+    " git://#{git_server}/#{repo}"
 end
 
 RSpec.configure do |c|


### PR DESCRIPTION
Previously we were using the SSH protocol to clone our opensource
dependencies from github when running integration tests.

The test machines do not always have SSH keys allowed by our github
account. This converts the integration setup steps to use the git
protocol.
