### PR TITLE
(maint) Call `install_*` methods only once per run

### DIFF
--- a/spec/spec_helper_integration.rb
+++ b/spec/spec_helper_integration.rb
@@ -41,13 +41,10 @@ RSpec.configure do |c|
         on master, puppet('resource group puppet ensure=present')
       end
     else
-      hosts.each do |host|
-        # Install Puppet
-        if host[:type] =~ /foss/
-          install_puppet
-        else
-          install_pe
-        end
+      if default[:type] =~ /foss/
+        install_puppet
+      else
+        install_pe
       end
     end
   end


### PR DESCRIPTION
The methods `install_puppet()` and `install_pe()` act on all hosts in a
node set. Calling the respective methods for each host will cause errors
when there are more two or more hosts in the node set.

This removes the iteration over the hosts.
