### PR TITLE
(PRE-31) Disable fact caching when PuppetDB is in use

### DIFF
--- a/lib/puppet/application/preview.rb
+++ b/lib/puppet/application/preview.rb
@@ -451,6 +451,9 @@ Output:
     # uses the v4 API which returns properly structured and typed facts.
     if Puppet::Node::Facts.indirection.terminus_class.to_s == 'puppetdb'
       Puppet::Node::Facts.indirection.terminus_class = :diff_puppetdb
+      # Ensure we don't accidentally use any facts that were cached from the
+      # PuppetDB v3 API.
+      Puppet::Node::Facts.indirection.cache_class = false
     end
   end
 


### PR DESCRIPTION
It is possible for calls to the PuppetDB v3 API to populate the fact cache with
stringified data. This commit disables the Fact cache terminus when PuppetDB is
in use so that we always fetch structured and typed facts from the v4 API.
