### PR TITLE
(maint) Remove beaker `step` usage

### DIFF
--- a/spec/spec_helper_integration.rb
+++ b/spec/spec_helper_integration.rb
@@ -32,14 +32,11 @@ RSpec.configure do |c|
       on master, "echo #{GitHubSig} >> $HOME/.ssh/known_hosts"
 
       repositories.each do |repository|
-        step "Install #{repository[:name]}"
         install_from_git master, SourcePath, repository
       end
 
-      step "ensure puppet user and group added to master because this is what the packages do" do
-        on master, puppet('resource user puppet ensure=present')
-        on master, puppet('resource group puppet ensure=present')
-      end
+      on master, puppet('resource user puppet ensure=present')
+      on master, puppet('resource group puppet ensure=present')
     else
       if default[:type] =~ /foss/
         install_puppet


### PR DESCRIPTION
Prior to this we had a couple errorious usages of Beaker's `step` method
(a method for organizing tests conceptually similar to RSpec's usage of
`context`).

I don't believe using this method with beaker-rspec was
ever intended to be supported, though it works in _some_ versions of
Beaker.

It does not work post Beaker 2.12.0 and this commit removes
usage of `step` so that it can support Beaker post 2.12.
