### PR TITLE
(PRE-40) Improve Forge quality metrics

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,7 @@
   "summary": "PE-only module providing catalog preview and migration features",
   "license": "PuppetLabs-Enterprise",
   "source": "https://github.com/puppetlabs/puppetlabs-catalog_preview",
-  "project_page": "https://github.com/puppetlabs/puppetlabs-catalog_preview",
+  "project_page": "https://forge.puppetlabs.com/puppetlabs/catalog_preview",
   "issues_url": "https://tickets.puppetlabs.com/browse/PRE",
   "tags": [
     "migration",
@@ -17,7 +17,20 @@
     "delta"
   ],
   "operatingsystem_support": [
-  
+  {
+    "operatingsystem":"RedHat",
+    "operatingsystemrelease":[ "5.0", "6.0", "7.0" ]
+  },
+  {
+    "operatingsystem": "Ubuntu",
+    "operatingsystemrelease": [
+    "10.04", "12.04", "14.04"
+    ]
+  },
+  {
+    "operatingsystem":"Debian",
+    "operatingsystemrelease":[ "6", "7" ]
+  }
   ],
   "requirements": [
     {


### PR DESCRIPTION
Previously we scored lower on Forge because our page was listed as private and our operating system support was missing. 

This change adds support for the master platforms that PE 3.8 supports and points the project page to the Forge URL.
