### PR TITLE
(PRE-34) Add view failed and diff nodes

### DIFF
--- a/lib/puppet/application/preview.rb
+++ b/lib/puppet/application/preview.rb
@@ -26,7 +26,7 @@ class Puppet::Application::Preview < Puppet::Application
   end
 
   option("--view OPTION") do |arg|
-    if %w{summary diff baseline preview baseline_log preview_log none status failed_nodes diff_nodes}.include?(arg)
+    if %w{overview summary diff baseline preview baseline_log preview_log none status failed_nodes diff_nodes}.include?(arg)
       options[:view] = arg.to_sym
     else
       raise "The --view option only accepts a restricted list of arguments. Run 'puppet preview --help' for more details"

--- a/lib/puppet_x/puppetlabs/preview/api/documentation/preview-help.md
+++ b/lib/puppet_x/puppetlabs/preview/api/documentation/preview-help.md
@@ -17,7 +17,7 @@ puppet preview [
     [-m|--migrate [--diff_string_numeric]]
     [--preview_outputdir <PATH-TO-OUTPUT-DIR>]
     [--skip_tags]
-    [--view summary|baseline|preview|diff|baseline_log|preview_log|none]
+    [--view summary|baseline|preview|diff|baseline_log|preview_log|none|failed_nodes|diff_nodes]
     [-vd|--verbose_diff]
     [--trusted]
     [--baseline_environment <ENV-NAME> | --be <ENV-NAME>]
@@ -121,10 +121,12 @@ Note that all settings (such as 'log_level') affect both compilations.
   Uses facts obtained from the configured facts terminus to compile the catalog.
   Note that the puppet setting '-environment' cannot be used to achieve the same effect.
 
-* --view summary | diff | baseline | preview | baseline_log | preview_log | status | none
+* --view summary | diff | baseline | preview | baseline_log | preview_log | status | none | failed_nodes | diff_nodes
   Specifies what will be output on stdout; the catalog diff, one of the two
   catalogs, or one of the two logs. The option 'status' displays a one line status of compliance.
-  The option 'none' turns off output to stdout.
+  The option 'none' turns off output to stdout. When running with multiple nodes, failed_nodes will
+  output a list of all nodes that failed compilation. diff_nodes will list all non-compliant nodes,
+  and if --assert equal is used, it will print all non-equal nodes.
 
 * --migrate
   Turns on migration validation for the preview compilation. Validation result


### PR DESCRIPTION
Add the ability to run with --view diff_nodes and failed_nodes when
compiling multiple nodes. When the flag is used, preview will print
out a white space separated list of node names that meet the criteria.
failed_nodes include only nodes that failed to compile. diff_nodes
will include failed nodes, diff nodes, and if the --assert equal flag
is used, compliant nodes.
