### PR TITLE
(PRE-32) Error for incompatible --view options

### DIFF
--- a/lib/puppet/application/preview.rb
+++ b/lib/puppet/application/preview.rb
@@ -148,6 +148,10 @@ class Puppet::Application::Preview < Puppet::Application
         raise "No node(s) given to perform preview compilation for"
       end
 
+      if options[:nodes].size > 1 && %w{diff baseline preview baseline_log preview_log status}.include?(options[:view].to_s)
+        raise "The --view option '#{options[:view]}' is not supported for multiple nodes"
+      end
+
       if options[:nodes].size == 1 && (options[:view] == :failed_nodes || options[:view] == :diff_nodes)
         raise "The 'failed_nodes' and 'diff_nodes' options for --view are only available when compiling multiple nodes"
       end


### PR DESCRIPTION
Prior to this commit, preview would not warn you if you were using
a --view option that only works for single node runs while running
with multiple nodes.

Update the preview application so that it will raise an error if
you are running with more than one node and using an incompatible
--view argument.
