### PR TITLE
(PRE-48) Add compiler errors and warnings to overview report

### DIFF
--- a/lib/puppet/application/preview.rb
+++ b/lib/puppet/application/preview.rb
@@ -29,7 +29,7 @@ class Puppet::Application::Preview < Puppet::Application
   end
 
   option('--view OPTION') do |arg|
-    if %w{overview summary diff baseline preview baseline_log preview_log none status failed_nodes diff_nodes equal_nodes compliant_nodes}.include?(arg)
+    if %w{overview overview_json summary diff baseline preview baseline_log preview_log none status failed_nodes diff_nodes equal_nodes compliant_nodes}.include?(arg)
       options[:view] = arg.to_sym
     else
       raise "The --view option only accepts a restricted list of arguments.\n#{RUNHELP}"
@@ -520,9 +520,15 @@ Output:
       TEXT
   end
 
-  def display_overview(overview, format)
+  # Outputs the given _overview_ on `$stdout`. The output is either in JSON format
+  # or in textual form as determined by _as_json_.
+  #
+  # @param overview [OverviewModel::Overview] the model to output
+  # @param as_json [Boolean] true for JSON output, false for textual output
+  #
+  def display_overview(overview, as_json)
     report = OverviewModel::Report.new(overview)
-    $stdout.puts(report.to_s)
+    $stdout.puts(as_json ? report.to_json : report.to_s)
   end
 
   def display_status(delta)
@@ -639,8 +645,9 @@ Output:
 
   # Sorts the map of nodes accordingly and computes statistics
   def report_results
-    if options[:view] == :overview
-      display_overview(@overview, :json)
+    view_type = options[:view]
+    if view_type == :overview || view_type == :overview_json
+      display_overview(@overview, view_type == :overview_json)
       return
     end
 
@@ -664,10 +671,10 @@ Output:
         result
       end
 
-      if options[:view] == :summary || options[:view] == nil
+      if view_type == :summary || view_type == nil
         multi_node_abstract(stats)
         multi_node_summary
-      elsif %w{failed_nodes diff_nodes equal_nodes compliant_nodes}.include?(options[:view].to_s)
+      elsif %w{failed_nodes diff_nodes equal_nodes compliant_nodes}.include?(view_type.to_s)
         print_node_list
       end
     else

--- a/lib/puppet_x/puppetlabs/migration/overview_model.rb
+++ b/lib/puppet_x/puppetlabs/migration/overview_model.rb
@@ -288,6 +288,16 @@ module PuppetX::Puppetlabs::Migration
           :log_entries => LogEntry.instance_method(:location_id)
         }
       end
+
+      def lp_string
+        if @line.nil?
+          '--'
+        elsif @pos.nil?
+          @line.to_s
+        else
+          "#{@line}:#{@pos}"
+        end
+      end
     end
 
     class Compilation < Entity
@@ -314,13 +324,19 @@ module PuppetX::Puppetlabs::Migration
       def baseline?
         @baseline
       end
+
+      def self.many_rels_hash
+        {
+          :log_entries => LogEntry.instance_method(:compilation_id)
+        }
+      end
     end
 
     class LogLevel < NamedEntity
       def self.many_rels_hash
         {
           :issues => LogIssue.instance_method(:level_id),
-          :entries => [LogIssue.instance_method(:level_id), LogMessage.instance_method(:issue_id), LogEntry.instance_method(:message_id) ]
+          :log_entries => [LogIssue.instance_method(:level_id), LogMessage.instance_method(:issue_id), LogEntry.instance_method(:message_id) ]
         }
       end
     end
@@ -343,7 +359,7 @@ module PuppetX::Puppetlabs::Migration
       def self.many_rels_hash
         {
           :messages => LogMessage.instance_method(:issue_id),
-          :entries => [LogMessage.instance_method(:issue_id), LogEntry.instance_method(:message_id) ]
+          :log_entries => [LogMessage.instance_method(:issue_id), LogEntry.instance_method(:message_id) ]
         }
       end
     end
@@ -367,7 +383,7 @@ module PuppetX::Puppetlabs::Migration
 
       def self.many_rels_hash
         {
-          :entries => LogEntry.instance_method(:message_id),
+          :log_entries => LogEntry.instance_method(:message_id),
         }
       end
     end

--- a/lib/puppet_x/puppetlabs/migration/overview_model/query.rb
+++ b/lib/puppet_x/puppetlabs/migration/overview_model/query.rb
@@ -53,6 +53,7 @@ module PuppetX::Puppetlabs::Migration::OverviewModel
       #
       def initialize(overview, entity)
         @overview = overview
+        raise ArgumentError unless entity.is_a?(Entity)
         @entity = entity
       end
 
@@ -99,7 +100,7 @@ module PuppetX::Puppetlabs::Migration::OverviewModel
             result.nil? ? nil : Wrapper.new(@overview, result)
           else
             if result.is_a?(Array)
-              WrappingArray.new(result.map { |entity| Wrapper.new(@overview, entity) })
+              WrappingArray.from_entities(@overview, result)
             else
               EMPTY_ARRAY
             end
@@ -144,6 +145,13 @@ module PuppetX::Puppetlabs::Migration::OverviewModel
     #
     # @api private
     class WrappingArray < Array
+      def self.from_entities(overview, entities)
+        entities.flatten!
+        entities.uniq!
+        entities.compact!
+        new(entities.map { |entity| Wrapper.new(overview, entity) })
+      end
+
       def of_class(eclass)
         select { |entity| entity.entity.is_a?(eclass) }
       end

--- a/spec/integration/preview_spec.rb
+++ b/spec/integration/preview_spec.rb
@@ -146,26 +146,26 @@ EOS
     end
   end
 
+  it 'should output valid json from --view overview_json' do
+    env_path = File.join(testdir_simple, 'environments')
+    on(master, puppet("preview --preview_environment test #{node_name} --environmentpath #{env_path} --view overview_json"),
+      {:catch_failures => true, :acceptable_exit_codes => [0]}) { |r| JSON.parse(r.stdout) }
+  end
+
   it 'should output valid json from --view baseline_log' do
     env_path = File.join(testdir_broken_production, 'environments')
-    on master, puppet("preview --preview_environment test #{node_name} --environmentpath #{env_path}"),
-      :acceptable_exit_codes => [2] do |r|
-    end
-    on master, puppet("preview --preview_environment test #{node_name} --environmentpath #{env_path} --last --view baseline_log"),
-      {:catch_failures => true, :acceptable_exit_codes => [0]} do |r|
-      JSON.parse(r.stdout)
-    end
+    on(master, puppet("preview --preview_environment test #{node_name} --environmentpath #{env_path}"),
+      :acceptable_exit_codes => [2]) { |r| }
+    on(master, puppet("preview --preview_environment test #{node_name} --environmentpath #{env_path} --last --view baseline_log"),
+      {:catch_failures => true, :acceptable_exit_codes => [0]}) { |r| JSON.parse(r.stdout) }
   end
 
   it 'should output valid json from --view preview_log' do
     env_path = File.join(testdir_broken_test, 'environments')
-    on master, puppet("preview --preview_environment test #{node_name} --environmentpath #{env_path}"),
-      :acceptable_exit_codes => [3] do |r|
-    end
-    on master, puppet("preview --preview_environment test #{node_name} --environmentpath #{env_path} --last --view preview_log"),
-      {:catch_failures => true, :acceptable_exit_codes => [0]} do |r|
-      JSON.parse(r.stdout)
-    end
+    on(master, puppet("preview --preview_environment test #{node_name} --environmentpath #{env_path}"),
+      :acceptable_exit_codes => [3]) { |r| }
+    on(master, puppet("preview --preview_environment test #{node_name} --environmentpath #{env_path} --last --view preview_log"),
+      {:catch_failures => true, :acceptable_exit_codes => [0]}) { |r| JSON.parse(r.stdout) }
   end
 
   it 'should fail to run and exit 1 if no node given' do

--- a/spec/unit/overview_model_spec.rb
+++ b/spec/unit/overview_model_spec.rb
@@ -134,12 +134,12 @@ module PuppetX::Puppetlabs::Migration
           expect(overview.of_class(LogEntry).message.issue.level).not_to be_empty
         end
 
-        it 'can navigate from level to entry viea issues and messages' do
-          expect(overview.of_class(LogLevel).issues.messages.entries).not_to be_empty
+        it 'can navigate from level to entry via issues and messages' do
+          expect(overview.of_class(LogLevel).issues.messages.log_entries).not_to be_empty
         end
 
         it 'can navigate directly from level to entry' do
-          expect(overview.of_class(LogLevel).entries).not_to be_empty
+          expect(overview.of_class(LogLevel).log_entries).not_to be_empty
         end
 
         it 'contains expected data' do

--- a/spec/unit/overview_report_spec.rb
+++ b/spec/unit/overview_report_spec.rb
@@ -6,22 +6,25 @@ module PuppetX::Puppetlabs::Migration
   module OverviewModel
     describe Report do
       let!(:conflicting_delta) { CatalogDeltaModel::CatalogDelta.from_hash(load_catalog_delta('conflicting-delta.json')) }
+      let!(:assignment_failed_log) { load_compile_log('assignment_failed.json') }
 
       context 'when reporting' do
         let!(:now) { Time.now.iso8601(9) }
-        let!(:overview) { Factory.new.merge(conflicting_delta).merge_failure('fail.example.com', 'production', now, 2).create_overview }
+        let!(:overview) { Factory.new.merge(conflicting_delta).merge_failure('failed.example.com', 'test', now, 2, assignment_failed_log).create_overview }
 
         let(:report) { Report.new(overview) }
 
         it 'can produce a hash' do
           hash = report.to_hash
-          expect(hash).to include(:stats, :top_ten, :changes)
+          expect(hash).to include(:stats, :baseline, :top_ten, :changes)
           expect(hash[:changes]).to include(:resource_type_changes, :edge_changes)
         end
 
         it 'can produce a text' do
           text = report.to_s
           expect(text).to match(/^Stats$/)
+          expect(text).to match(/^Baseline compilation errors per manifest$/)
+          expect(text).to match(/^Baseline Errors by issue code$/)
           expect(text).to match(/^Top ten nodes with most issues$/)
           expect(text).to match(/^Changes per Resource Type$/)
           expect(text).to match(/^Changes of Edges$/)


### PR DESCRIPTION
This commit adds two sections to the overview report, one each for the baseline and preview compilations. Each section contains three entries:
- Compilation errors per manifest.
- Error counts per issue code.
- Warning counts per issue code.

The commit also adds the additional option _--view overview_json_ which enables output of the overview report in JSON format (using _--view overview_ generates formatted text output).
