### PR TITLE
(PRE-53) Handle resources without location correctly

### DIFF
--- a/lib/puppet_x/puppetlabs/migration/overview_model/factory.rb
+++ b/lib/puppet_x/puppetlabs/migration/overview_model/factory.rb
@@ -219,7 +219,7 @@ module PuppetX::Puppetlabs::Migration
       #
       # @api public
       def location_from_delta(loc)
-        location(loc.file, loc.line, nil)
+        loc.nil? ? nil : location(loc.file, loc.line, nil)
       end
 
       # Returns the id of the {Location} entity that corresponds to the given parameters. A new

--- a/lib/puppet_x/puppetlabs/migration/overview_model/report.rb
+++ b/lib/puppet_x/puppetlabs/migration/overview_model/report.rb
@@ -150,7 +150,7 @@ module PuppetX::Puppetlabs::Migration::OverviewModel
 
     def issue_location_string(issue)
       location = issue.location
-      "#{location.file.path}:#{location.line}"
+      location.nil? ? 'unknown location' : "#{location.file.path}:#{location.line}"
     end
 
     # top_ten

--- a/spec/fixtures/catalog_deltas/conflict-without-location-delta.json
+++ b/spec/fixtures/catalog_deltas/conflict-without-location-delta.json
@@ -1,0 +1,110 @@
+{
+  "produced_by": "puppet preview 3.8.0",
+  "timestamp": "2015-06-11T13:08:41.289367239+02:00",
+  "baseline_catalog": "/home/bob/.puppet/var/preview/test.example.com/baseline_catalog.json",
+  "preview_catalog": "/home/bob/.puppet/var/preview/test.example.com/preview_catalog.json",
+  "node_name": "test.example.com",
+  "baseline_env": "production",
+  "preview_env": "preview",
+  "version_equal": true,
+  "baseline_resource_count": 5,
+  "preview_resource_count": 7,
+  "added_resources": [
+    {
+      "location": {
+        "file": "/etc/puppet/environments/preview/manifests/site.pp",
+        "line": 6
+      },
+      "type": "Stage",
+      "title": "first",
+      "diff_id": 1
+    },
+    {
+      "location": {
+        "file": "/etc/puppet/environments/preview/manifests/site.pp",
+        "line": 9
+      },
+      "type": "Stage",
+      "title": "last",
+      "diff_id": 2
+    }
+  ],
+  "added_resource_count": 2,
+  "added_attribute_count": 6,
+  "missing_resources": [
+
+  ],
+  "missing_resource_count": 0,
+  "missing_attribute_count": 0,
+  "equal_resource_count": 3,
+  "equal_attribute_count": 12,
+  "conflicting_attribute_count": 1,
+  "conflicting_resources": [
+    {
+      "type": "Stage",
+      "title": "main",
+      "equal_attribute_count": 3,
+      "added_attributes": [
+        {
+          "name": "before",
+          "value": "#<Set:0x0000000556a888>",
+          "diff_id": 4
+        }
+      ],
+      "added_attribute_count": 1,
+      "missing_attributes": [
+
+      ],
+      "missing_attribute_count": 0,
+      "conflicting_attributes": [
+
+      ],
+      "conflicting_attribute_count": 0,
+      "diff_id": 3
+    },
+    {
+      "baseline_location": {
+        "file": "/etc/puppet/environments/production/manifests/site.pp",
+        "line": 4
+      },
+      "preview_location": {
+        "file": "/etc/puppet/environments/preview/manifests/site.pp",
+        "line": 2
+      },
+      "type": "Notify",
+      "title": "preview compile diff test",
+      "equal_attribute_count": 2,
+      "added_attributes": [
+
+      ],
+      "added_attribute_count": 0,
+      "missing_attributes": [
+
+      ],
+      "missing_attribute_count": 0,
+      "conflicting_attributes": [
+        {
+          "name": "message",
+          "baseline_value": "42",
+          "preview_value": 42,
+          "diff_id": 6
+        }
+      ],
+      "conflicting_attribute_count": 1,
+      "diff_id": 5
+    }
+  ],
+  "conflicting_resource_count": 2,
+  "baseline_edge_count": 4,
+  "preview_edge_count": 4,
+  "added_edges": [
+
+  ],
+  "added_edge_count": 0,
+  "missing_edges": [
+
+  ],
+  "missing_edge_count": 0,
+  "preview_compliant": false,
+  "preview_equal": false
+}

--- a/spec/unit/overview_model_spec.rb
+++ b/spec/unit/overview_model_spec.rb
@@ -6,6 +6,7 @@ module PuppetX::Puppetlabs::Migration
   module OverviewModel
     describe 'Factory' do
       let!(:conflicting_delta) { CatalogDeltaModel::CatalogDelta.from_hash(load_catalog_delta('conflicting-delta.json')) }
+      let!(:conflict_without_location_delta) { CatalogDeltaModel::CatalogDelta.from_hash(load_catalog_delta('conflict-without-location-delta.json')) }
       let!(:compliant_delta) { CatalogDeltaModel::CatalogDelta.from_hash(load_catalog_delta('compliant-delta.json')) }
       let!(:equal_delta_hash) { load_catalog_delta('equal-delta.json')}
       let!(:equal_delta) { CatalogDeltaModel::CatalogDelta.from_hash(equal_delta_hash) }
@@ -47,6 +48,12 @@ module PuppetX::Puppetlabs::Migration
         factory.merge(conflicting_delta)
         overview_hash2 = factory.create_overview.to_hash
         expect(overview_hash1).to eq(overview_hash2)
+      end
+
+      it 'can merge a CatalogDelta that has resources with no file/line information' do
+        factory.merge(conflict_without_location_delta)
+        overview = factory.create_overview
+        expect(overview.of_class(ResourceIssue).select { |r| r.location.nil? }.size).to eq(1)
       end
 
       context 'when queried' do


### PR DESCRIPTION
Not all resources have a location which means that there's a potential
for location less resource issues in the delta. This commit ensures
that the delta and overview can handle this.
