### PR TITLE
(maint) fix Gemfile and find correct puppet version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,6 @@ group :test do
   gem 'rake'
   gem 'puppet', *location_for(ENV['PUPPET_LOCATION'] || ENV['PUPPET_VERSION'] || '~> 3.8.0')
   gem 'puppet-lint'
-#  gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git'
   gem 'puppet-syntax'
   gem 'beaker'
   gem 'beaker-rspec'

--- a/spec/integration/preview_spec.rb
+++ b/spec/integration/preview_spec.rb
@@ -1,4 +1,3 @@
-require 'puppet'
 require 'spec_helper_integration'
 require 'json'
 
@@ -22,7 +21,8 @@ describe 'preview subcommand' do
   testdir_broken_production = master.tmpdir('preview_broken_production')
   testdir_broken_test       = master.tmpdir('preview_broken_test')
   # Do not use parser=future in environment configurations for version >= 4.0.0 since it has been removed
-  use_future_parser          = Puppet.version =~ /^3\./ ? 'parser=future' : ''
+  puppet_version            =  on(master, 'puppet --version').stdout.chomp
+  use_future_parser         =  puppet_version =~ /^3\./ ? 'parser=future' : ''
 
   pp = <<-EOS
 File {
@@ -203,7 +203,7 @@ EOS
                 :acceptable_exit_codes => [5]
   end
 
-  if Puppet.version =~ /^3\./ # constrained to >= 3.8.0 in dependencies
+  if puppet_version =~ /^3\./ # constrained to >= 3.8.0 in dependencies
 
     it 'accepts --migrate 3.8/4.0' do
       env_path = File.join(testdir_simple, 'environments')

--- a/spec/spec_helper_integration.rb
+++ b/spec/spec_helper_integration.rb
@@ -17,7 +17,7 @@ end
 
 RSpec.configure do |c|
   unless ENV['RS_PROVISION'] == 'no' or ENV['BEAKER_provision'] == 'no'
-    puppet_sha   = ENV['PUPPET_VERSION']
+    puppet_sha   = ENV['PUPPET_VER']
     if hosts.options[:type] =~ /foss/ && puppet_sha
       install_package(master, 'git')
       tmp_repositories = []


### PR DESCRIPTION
Prior to this change the acceptance tests were finding the puppet
version installed on the test runner during the bundle install (or gem
installed version).  This change asks the SUT what puppet version is
installed.
This change also removes the puppet requirements for the :test group in
the Gemfile.
