### PR TITLE
(PRE-49) add acceptance tests for --view failed_nodes and diff_nodes

### DIFF
--- a/spec/integration/preview_spec.rb
+++ b/spec/integration/preview_spec.rb
@@ -168,6 +168,34 @@ EOS
       {:catch_failures => true, :acceptable_exit_codes => [0]}) { |r| JSON.parse(r.stdout) }
   end
 
+  it 'should --view diff_nodes' do
+    env_path = File.join(testdir_simple, 'environments')
+    on master, puppet("preview --preview_environment test #{node_name} --environmentpath #{env_path} --view diff_nodes"),
+      :acceptable_exit_codes => [0] do |r|
+      expect(r.stderr).to be_empty
+      expect(r.stdout).to match(/#{node_name}/)
+    end
+  end
+
+  it 'should output nothing from --view failed_nodes with no failed nodes' do
+    env_path = File.join(testdir_simple, 'environments')
+    on master, puppet("preview --preview_environment test #{node_name} --environmentpath #{env_path} --view failed_nodes"),
+      {:acceptable_exit_codes => [0]} do |r|
+      expect(r.exit_code).to be_zero
+      expect(r.stderr).to be_empty
+      expect(r.stdout).to be_empty
+    end
+  end
+
+  it 'should show the error and the failed nodes with --view failed_nodes' do
+    env_path = File.join(testdir_broken_test, 'environments')
+    on master, puppet("preview --preview_environment test #{node_name} --environmentpath #{env_path} --view failed_nodes"),
+      :acceptable_exit_codes => [3] do |r|
+      expect(r.stderr).to match(/ERROR: Could not parse for environment test/)
+      expect(r.stdout).to match(/#{node_name}/)
+    end
+  end
+
   it 'should fail to run and exit 1 if no node given' do
     env_path = File.join(testdir_simple, 'environments')
     on master, puppet("preview --preview_environment test --environmentpath #{env_path}"), :acceptable_exit_codes => [1] do |r|


### PR DESCRIPTION
This change adds simple tests for single node use of failed_nodes and
diff_nodes --view types. Later commits should alter these for multiple
nodes.
