### PR TITLE
(PRE-59) Add support for --excludes EXCLUDES_FILE

### DIFF
--- a/lib/puppet_x/puppetlabs/migration/catalog_delta_model.rb
+++ b/lib/puppet_x/puppetlabs/migration/catalog_delta_model.rb
@@ -1,6 +1,7 @@
 require_relative 'model_object'
 
-module PuppetX::Puppetlabs::Migration::CatalogDeltaModel
+module PuppetX::Puppetlabs::Migration
+module CatalogDeltaModel
   class DeltaEntity
     include PuppetX::Puppetlabs::Migration::ModelObject
 
@@ -9,6 +10,34 @@ module PuppetX::Puppetlabs::Migration::CatalogDeltaModel
       instance.initialize_from_hash(hash)
       instance
     end
+  end
+
+  class Exclude < DeltaEntity
+    attr_reader :type
+    attr_reader :title
+    attr_reader :attributes
+
+    def initialize(type, title, attributes)
+      @type = assert_type(String, type)
+      @title = assert_type(String, title)
+      @attributes = assert_type(Array, attributes)
+    end
+
+    def self.parse_file(file_name)
+      json = File.read(file_name)
+      raise Puppet::Error.new('Excludes file must contain well formed JSON') if json.nil? || json.empty?
+      parse_json(json)
+    end
+
+    def self.parse_json(json)
+      array = JSON.load(json)
+      raise Puppet::Error.new('Excludes file must contain a JSON Array') unless array.is_a?(Array)
+      array.map { |hash| Exclude.new(hash['type'], hash['title'], hash['attributes']) }
+    end
+
+    DEFAULT_EXCLUSIONS = [
+      Exclude.new('file', '/etc/puppetlabs/console-services/conf.d/console_secret_key.conf', ['content'])
+    ]
   end
 
   # Denotes a line in a file
@@ -65,6 +94,7 @@ module PuppetX::Puppetlabs::Migration::CatalogDeltaModel
     def assign_ids_on_each(start, array)
       array.nil? ? start : array.inject(start) { |n, a| a.assign_ids(n) }
     end
+
     private :assign_ids_on_each
   end
 
@@ -522,9 +552,17 @@ module PuppetX::Puppetlabs::Migration::CatalogDeltaModel
     # @param preview [Hash<Symbol,Object] the hash representing the preview catalog
     # @param options [Hash<Symbol,Object>] preview options
     # @param timestamp [String] when preview run began. In ISO 8601 format with 9 characters second-fragment
+    # @param excludes [Array<Exclusion>>] excludes,
     #
     # @api public
-    def initialize(baseline, preview, options, timestamp)
+    def initialize(baseline, preview, options, timestamp, excludes = EMPTY_ARRAY)
+      excludes_per_type = {}
+      (Exclude::DEFAULT_EXCLUSIONS + excludes).each do |ex|
+        type = ex.type.downcase
+        ex_for_type = (excludes_per_type[type] ||= [])
+        ex_for_type << ex
+      end
+
       @produced_by      = 'puppet preview 3.8.0'
       @timestamp        = timestamp
       @baseline_catalog = options[:baseline_catalog]
@@ -540,11 +578,11 @@ module PuppetX::Puppetlabs::Migration::CatalogDeltaModel
       @preview_env      = preview['environment']
       @version_equal    = baseline['version'] == preview['version']
 
-      baseline_resources = create_resources(baseline)
+      baseline_resources = create_resources(baseline, excludes_per_type)
       @baseline_resource_count = baseline_resources.size
 
 
-      preview_resources = create_resources(preview)
+      preview_resources = create_resources(preview, excludes_per_type)
       @preview_resource_count = preview_resources.size
 
       @added_resources = preview_resources.reject { |key,_| baseline_resources.include?(key) }.values
@@ -629,7 +667,7 @@ module PuppetX::Puppetlabs::Migration::CatalogDeltaModel
 
     # @param br [Resource] Baseline resource
     # @param pr [Resource] Preview resource
-    # @return [ResourceConflict]
+    # @return [ResourceConflict,nil]
     # @api private
     def create_resource_conflict(br, pr)
       added_attributes = pr.attributes.reject { |key, _| br.attributes.include?(key) }.values
@@ -724,23 +762,31 @@ module PuppetX::Puppetlabs::Migration::CatalogDeltaModel
     end
 
     # @param hash [Hash] a Catalog hash
+    # @param excludes_per_type [Hash<String,Array<Exclude>>] resources and/or attributes to exclude, keyed by type
     # @return [Hash<String,Resource>] a Hash of Resource objects keyed by the Resource#key
     # @api private
-    def create_resources(hash)
+    def create_resources(hash, excludes_per_type)
       result = {}
       assert_type(Array, hash['resources'], []).each do |rh|
-        resource = create_resource(rh)
-        result[resource.key] = resource
+        type = rh['type']
+        title = rh['title']
+        excludes = excludes_per_type[type.downcase] || EMPTY_ARRAY
+        unless excludes.any? { |ex| ex.title.nil? }
+          resource = create_resource(rh, excludes.select { |ex| ex.title == title })
+          result[resource.key] = resource
+        end
       end
       result
     end
     private :create_resources
 
     # @param resource [Hash] a Resource hash
+    # @param excludes [Array<Exclude>] Excludes for the resource
     # @return [Resource]
     # @api private
-    def create_resource(resource)
-      Resource.new(create_location(resource), resource['type'], resource['title'], create_attributes(resource))
+    def create_resource(resource, excludes)
+      attributes = excludes.any? { |ex| ex.attributes.nil? } ? EMPTY_ARRAY : create_attributes(resource, excludes.map { |ex| ex.attributes }.flatten)
+      Resource.new(create_location(resource), resource['type'], resource['title'], attributes)
     end
     private :create_resource
 
@@ -771,16 +817,20 @@ module PuppetX::Puppetlabs::Migration::CatalogDeltaModel
     private :create_location
 
     # @param resource [Array<Hash>] a Resource hash
+    # @param excludes [Array<String>] attribute names to exclude
     # @return [Hash<String,Attribute>]
     # @api private
-    def create_attributes(resource)
+    def create_attributes(resource, excludes)
       attrs = {}
-      attrs['tags'] = Attribute.new('tags', assert_type(Array, resource['tags'], []))
-      attrs['@@'] = Attribute.new('@@', assert_boolean(resource['exported'], false))
-      assert_type(Hash, resource['parameters'], {}).each_pair { |name, value| attrs[name] = Attribute.new(name, value)}
+      attrs['tags'] = Attribute.new('tags', assert_type(Array, resource['tags'], [])) unless excludes.include?('tags')
+      attrs['@@'] = Attribute.new('@@', assert_boolean(resource['exported'], false)) unless excludes.include?('@@')
+      assert_type(Hash, resource['parameters'], {}).each_pair do |name, value|
+        attrs[name] = Attribute.new(name, value) unless excludes.include?(name)
+      end
       attrs
     end
     private :create_attributes
   end
+end
 end
 

--- a/lib/puppet_x/puppetlabs/migration/overview_model.rb
+++ b/lib/puppet_x/puppetlabs/migration/overview_model.rb
@@ -5,16 +5,6 @@ require_relative 'overview_model/report'
 
 module PuppetX::Puppetlabs::Migration
   module OverviewModel
-    DOUBLE_COLON = '::'.freeze
-    EMPTY_HASH = {}.freeze
-    EMPTY_ARRAY = [].freeze
-    UNDEFINED_ID = -1
-
-    CATALOG_DELTA = 0
-    GENERAL_ERROR = 1
-    BASELINE_FAILED = 2
-    PREVIEW_FAILED = 3
-
     # Abstract base class for all entities in the overview model.
     #
     # @abstract

--- a/lib/puppet_x/puppetlabs/migration/overview_model/query.rb
+++ b/lib/puppet_x/puppetlabs/migration/overview_model/query.rb
@@ -1,4 +1,5 @@
-module PuppetX::Puppetlabs::Migration::OverviewModel
+module PuppetX::Puppetlabs::Migration
+module OverviewModel
   module Query
     # @abstract
     class RelationalStep
@@ -17,7 +18,7 @@ module PuppetX::Puppetlabs::Migration::OverviewModel
       # @param collection [Array<Entity>] The collection
       # @return [Entity,nil] The entity or nil
       def evaluate(collection)
-         collection.is_a?(Array) ? collection.first : nil
+        collection.is_a?(Array) ? collection.first : nil
       end
     end
 
@@ -215,7 +216,7 @@ module PuppetX::Puppetlabs::Migration::OverviewModel
 
       def slice(*args)
         wrap(super)
-     end
+      end
 
       def select
         wrap(super)
@@ -342,3 +343,5 @@ module PuppetX::Puppetlabs::Migration::OverviewModel
     end
   end
 end
+end
+

--- a/lib/puppet_x/puppetlabs/migration/overview_model/report.rb
+++ b/lib/puppet_x/puppetlabs/migration/overview_model/report.rb
@@ -1,4 +1,5 @@
-module PuppetX::Puppetlabs::Migration::OverviewModel
+module PuppetX::Puppetlabs::Migration
+module OverviewModel
   class Report
     # Creates a new {Report} instance based on an {Overview}.
     # @param overview [Overview] the overview to create a report from
@@ -20,6 +21,7 @@ module PuppetX::Puppetlabs::Migration::OverviewModel
       hash[:preview] = preview unless preview.empty?
       hash
     end
+
     # Creates and returns a formatted JSON string that represents the content of the report
     # @return [String] The JSON representation of this report
     def to_json
@@ -444,3 +446,5 @@ module PuppetX::Puppetlabs::Migration::OverviewModel
     end
   end
 end
+end
+

--- a/lib/puppet_x/puppetlabs/preview.rb
+++ b/lib/puppet_x/puppetlabs/preview.rb
@@ -4,6 +4,16 @@ require 'puppet/pops'
 module PuppetX
   module Puppetlabs
     module Migration
+      DOUBLE_COLON = '::'.freeze
+      EMPTY_HASH = {}.freeze
+      EMPTY_ARRAY = [].freeze
+      UNDEFINED_ID = -1
+
+      CATALOG_DELTA = 0
+      GENERAL_ERROR = 1
+      BASELINE_FAILED = 2
+      PREVIEW_FAILED = 3
+
       require 'puppet_x/puppetlabs/migration/migration_issues'
       require 'puppet_x/puppetlabs/migration/migration_checker'
       require 'puppet_x/puppetlabs/migration/catalog_delta_model'

--- a/lib/puppet_x/puppetlabs/preview/api/schemas/excludes.json
+++ b/lib/puppet_x/puppetlabs/preview/api/schemas/excludes.json
@@ -1,0 +1,31 @@
+{
+    "$schema":"http://json-schema.org/draft-04/schema#",
+    "title":"Catalog Delta Excludes",
+    "description": "Array of entries to describe attributes to be excluded for a given resource in a diff",
+    "type":"array",
+    "items":{
+        "$ref":"#/definitions/exclude_entry"
+    },
+    "definitions":{
+        "exclude_entry":{
+        "type":        "object",
+        "properties": {
+            "type": {
+                "description": "The type that this exclusion affects",
+                "type": "string"
+            },
+            "title": {
+                "description": "The title that this exclusion affects. If missing, all resources of the given 'type' are excluded",
+                "type": "string"
+            },
+            "attributes": {
+                "description": "The attributes to exclude. If missing, all attributes for the given 'title' are excluded",
+                "type": "array",
+                "items": { "type": "string" }
+            }
+        },
+        "required": ["type"],
+        "additionalProperties": false
+        }
+    }
+}

--- a/spec/fixtures/excludes/excludes.json
+++ b/spec/fixtures/excludes/excludes.json
@@ -1,0 +1,14 @@
+[
+    {
+        "type": "class"
+    },
+    {
+        "type": "file",
+        "title": "/tmp/footest"
+    },
+    {
+        "type": "file",
+        "title": "/tmp/fumtest",
+        "attributes": ["before", "after"]
+    }
+]


### PR DESCRIPTION
Add --exclude EXCLUDES_FILE option to the command line to enable the production
diffs where certain attributes, titles, or types have been excluded. A hard-
coded default to exclude the the 'content' attribute of the 'file' resource
'/etc/puppetlabs/console-services/conf.d/console_secret_key.conf' is also
added in this commit.

The JSON schema for the EXCLUDES_FILE can be found in
'lib/puppet_x/puppetlabs/preview/api/schemas/excludes.json'
