### PR TITLE
(PRE-61) Ensure that environment is propagated on compile failure

### DIFF
--- a/lib/puppet_x/puppetlabs/migration/overview_model/query.rb
+++ b/lib/puppet_x/puppetlabs/migration/overview_model/query.rb
@@ -243,6 +243,10 @@ module PuppetX::Puppetlabs::Migration::OverviewModel
         dispatch(:message)
       end
 
+      def exit_code
+        dispatch(:exit_code)
+      end
+
       def respond_to_missing?(name, include_private)
         true # We dispatch all unknown messages to each instance
       end

--- a/lib/puppet_x/puppetlabs/migration/overview_model/report.rb
+++ b/lib/puppet_x/puppetlabs/migration/overview_model/report.rb
@@ -223,7 +223,7 @@ module PuppetX::Puppetlabs::Migration::OverviewModel
         manifest_errors = (manifest_hash[:errors] ||= [])
         manifest_errors << error
       end
-      errors.map { |_, m| m[:nodes] = m[:nodes].to_a; m }.sort { |a, b| b[:nodes].size <=> a[:nodes.size] }
+      errors.map { |_, m| m[:nodes] = m[:nodes].to_a; m }.sort { |a, b| b[:nodes].size <=> a[:nodes].size }
     end
 
     def compilation_errors_to_s(bld, errors, baseline)


### PR DESCRIPTION
Prior to this commit the environment was never stored in any file
unless the diff succeeded. A consequence of that was that the
overview report didn't display correctly.

This commit adds a new file named compile_info.json that stores
information about the compile (time, exit_code, and environment
names) regardless of the outcome of the compilation. This info
is then used when recreating the overview by using the --last
option.
