### PR TITLE
(PRE-47) Warn when desired data is not available with running with --last

### DIFF
--- a/lib/puppet/application/preview.rb
+++ b/lib/puppet/application/preview.rb
@@ -167,20 +167,7 @@ class Puppet::Application::Preview < Puppet::Application
       end
 
       if options[:last]
-        node_directories = Dir["#{Puppet[:preview_outputdir]}/*"]
-        if node_directories.empty?
-          raise "There is no preview data in the specified output directory '#{Puppet[:preview_outputdir]}', you must have data from a previous preview run to use --last"
-        else
-          available_nodes = []
-          node_directories.each { |dir| available_nodes << dir.match(/^.*\/([^\/]*)$/)[1] }
-
-          node_names.each do |node|
-            if !available_nodes.include?(node)
-              raise "There is no preview data available for node '#{node}'. It is likely this node has not been compiled with preview."
-            end
-          end
-          last
-        end
+        last
       else
         unless options[:preview_environment]
           raise 'No --preview_environment given - cannot compile and produce a diff when only the environment of the node is known'
@@ -356,8 +343,21 @@ class Puppet::Application::Preview < Puppet::Application
   end
 
   def last
-    prepare_output_options
-    view
+    node_directories = Dir["#{Puppet[:preview_outputdir]}/*"]
+    if node_directories.empty?
+      raise "There is no preview data in the specified output directory '#{Puppet[:preview_outputdir]}', you must have data from a previous preview run to use --last"
+    else
+
+      available_nodes = []
+      node_directories.each { |dir| available_nodes << dir.match(/^.*\/([^\/]*)$/)[1] }
+
+      unless (missing_nodes = node_names - available_nodes).empty?
+        raise "No preview data available for node(s) '#{missing_nodes.join(", ")}'"
+      end
+
+      prepare_output_options
+      view
+    end
   end
 
   def clean

--- a/spec/unit/preview_spec.rb
+++ b/spec/unit/preview_spec.rb
@@ -13,20 +13,23 @@ describe Puppet::Application::Preview do
 
     it "warns if there is no preview data in the specified output direcotry" do
       preview.options[:last] = true
-      Puppet[:preview_outputdir] = "/test/dir"
-      stub_outputdir_contents([])
 
-      expected_error = "There is no preview data in the specified output directory '/test/dir', you must have data from a previous preview run to use --last"
+      Dir.mktmpdir do |dir|
+        Puppet[:preview_outputdir] = "#{dir}"
+        stub_outputdir_contents([])
 
-      expect{ preview.run_command }.to raise_error(RuntimeError, expected_error)
+        expected_error = "There is no preview data in the specified output directory '#{dir}', you must have data from a previous preview run to use --last"
+
+        expect{ preview.run_command }.to raise_error(RuntimeError, expected_error)
+      end
     end
 
     it "warns if there is no directory for the specified node" do
       stub_outputdir_contents(["fake/path/dir_a", "fake/path/dir_b"])
-      preview.options[:nodes] = ['some.node.com']
+      preview.options[:nodes] = ['some.node.com', 'another.node.com']
       preview.options[:last] = true
 
-      expected_error = "There is no preview data available for node 'some.node.com'. It is likely this node has not been compiled with preview."
+      expected_error = "No preview data available for node(s) 'some.node.com, another.node.com'"
 
       expect { preview.run_command}.to raise_error(RuntimeError, expected_error)
     end


### PR DESCRIPTION
Issue a helpful warning when the user is running with --last and the following scenarios occur:

1) the preview output directory is empty, suggesting that there is not a previous preview run
2) the users requests data for a node that does not have a directory in the preview output directory

If the directory is present and the files are not what preview is expecting, different warnings will be issued because this scenario suggests that the user has altered the files that are present.
