### PR TITLE
(PRE-47) Improve --last with no nodes errors

### DIFF
--- a/lib/puppet/application/preview.rb
+++ b/lib/puppet/application/preview.rb
@@ -162,7 +162,7 @@ class Puppet::Application::Preview < Puppet::Application
         raise 'No node(s) given to perform preview compilation for'
       end
 
-      if options[:nodes].size > 1 && %w{diff baseline preview baseline_log preview_log }.include?(options[:view].to_s)
+      if node_names.size > 1 && %w{diff baseline preview baseline_log preview_log }.include?(options[:view].to_s)
         raise "The --view option '#{options[:view]}' is not supported for multiple nodes"
       end
 


### PR DESCRIPTION
Prior to this commit, you could indirectly run single node view
options against multiple nodes by using --last with no node arguments.
Improve the error checking to ensure that preview will error out in
this case.
