### PR TITLE
(PRE-44) add multiple node tests

### DIFF
--- a/spec/integration/preview_spec.rb
+++ b/spec/integration/preview_spec.rb
@@ -159,23 +159,29 @@ file { '#{testdir_broken_test}/environments/test/manifests/init.pp':
 }
 EOS
 
-  apply_manifest(pp, :catch_failures => true)
-  node_name = 'nonesuch'
+  apply_manifest_on(master, pp, :catch_failures => true)
+  node_names_cli = ['nonesuch', 'andanother']
+  node_names_file = ['file_node1', 'file_node2']
+  node_names_all = node_names_cli + node_names_file
+  node_names_filename = '/root/nodez'
+  create_remote_file(master, node_names_filename, node_names_file.join(' '))
 
   it 'should be able to compare simple catalogs and exit with 0 and produce json logfiles' do
     env_path = File.join(testdir_simple, 'environments')
-    on master, puppet("preview --preview_environment test #{node_name} --environmentpath #{env_path}"),
+    on master, puppet("preview --preview_environment test #{node_names_cli.join(' ')} --nodes #{node_names_filename} --environmentpath #{env_path}"),
                 {:catch_failures => true} do |r|
       expect(r.exit_code).to be_zero
+    end
 
-      vardir = on(master, puppet('master --configprint vardir')).stdout.strip
-      logfile_extension  = '.json'
-      # create a string to send to on master that tests all the files at once
-      test_files_short   = ['baseline_catalog','baseline_log','catalog_diff','preview_catalog','preview_log']
-      # make the filenames fully qualified and with extensions
+    vardir = on(master, puppet('master --configprint vardir')).stdout.strip
+    logfile_extension  = '.json'
+    # create a string to send to on master that tests all the files at once
+    test_files_short   = ['baseline_catalog','baseline_log','catalog_diff','preview_catalog','preview_log']
+    # make the filenames fully qualified and with extensions
+    node_names_all.each do |node_name|
       test_files_long    = test_files_short.map { |logfile| File.join(vardir,'preview',node_name,logfile + logfile_extension) }
       # add the test to each filename
-      test_strings       = test_files_long.map { |logfile| "test -s #{logfile}" }
+      test_strings       = test_files_long.map { |logfile| "test -f #{logfile}" }
       # join the array with && to test each file in series
       test_files_command = test_strings.join(' && ')
       on master, test_files_command
@@ -187,12 +193,6 @@ EOS
       end
     end
   end
-
-  # TODO: TESTS TO ADD
-  # TODO: same as for one node, but for multiple nodes (just given on the command line)
-  # TODO: same as for multiple nodes but for nodes from a file (--nodes filename)
-  # TODO: same as for multiple nodes but for nodes from stdin (--nodes -)
-  # TODO: same as for multiple nodes mixing explicitly given nodes with those given with --nodes (unique set)
 
   # view types: [summary|overview|overview_json|baseline|preview|diff|baseline_log|preview_log|none|
   # failed_nodes|diff_nodes|compliant_nodes|equal_nodes]
@@ -206,9 +206,10 @@ EOS
     end
   end
 
+  let(:first) {0}
   it 'should output valid json from --view diff' do
     env_path = File.join(testdir_simple, 'environments')
-    on master, puppet("preview --preview_environment test #{node_name} --environmentpath #{env_path} --view diff"),
+    on master, puppet("preview --preview_environment test #{node_names_cli[first]} --environmentpath #{env_path} --view diff"),
                 {:catch_failures => true} do |r|
       expect(r.exit_code).to be_zero
       JSON.parse(r.stdout)
@@ -217,69 +218,69 @@ EOS
 
   it 'should output valid json from --view overview_json' do
     env_path = File.join(testdir_simple, 'environments')
-    on(master, puppet("preview --preview_environment test #{node_name} --environmentpath #{env_path} --view overview_json"),
+    on(master, puppet("preview --preview_environment test #{node_names_cli.join(' ')} --nodes #{node_names_filename} --environmentpath #{env_path} --view overview_json"),
       {:catch_failures => true, :acceptable_exit_codes => [0]}) { |r| JSON.parse(r.stdout) }
   end
 
   it 'should output valid json from --view baseline_log' do
     env_path = File.join(testdir_broken_production, 'environments')
-    on(master, puppet("preview --preview_environment test #{node_name} --environmentpath #{env_path}"),
+    on(master, puppet("preview --preview_environment test #{node_names_cli[first]} --environmentpath #{env_path}"),
       :acceptable_exit_codes => [2]) { |r| }
-    on(master, puppet("preview #{node_name} --last --view baseline_log"),
+    on(master, puppet("preview #{node_names_cli[first]} --last --view baseline_log"),
       {:catch_failures => true, :acceptable_exit_codes => [0]}) { |r| JSON.parse(r.stdout) }
   end
 
   it 'should output valid json from --view preview_log' do
     env_path = File.join(testdir_broken_test, 'environments')
-    on(master, puppet("preview --preview_environment test #{node_name} --environmentpath #{env_path}"),
+    on(master, puppet("preview --preview_environment test #{node_names_cli[first]} --environmentpath #{env_path}"),
       :acceptable_exit_codes => [3]) { |r| }
-    on(master, puppet("preview #{node_name} --last --view preview_log"),
+    on(master, puppet("preview #{node_names_cli[first]} --last --view preview_log"),
       {:catch_failures => true, :acceptable_exit_codes => [0]}) { |r| JSON.parse(r.stdout) }
   end
 
   it 'should reconstruct the node list from a previous successful run when using --last' do
     env_path = File.join(testdir_simple, 'environments')
-    on(master, puppet("preview --preview_environment test #{node_name} --environmentpath #{env_path}"),
+    on(master, puppet("preview --preview_environment test #{node_names_cli.join(' ')} --nodes #{node_names_filename} --environmentpath #{env_path}"),
       :acceptable_exit_codes => [0]) { |r| }
     on(master, puppet("preview --last --view diff_nodes"),
-      {:catch_failures => true, :acceptable_exit_codes => [0]}) { |r| expect(r.stdout).to match(/#{node_name}/) }
+      {:catch_failures => true, :acceptable_exit_codes => [0]}) { |r| expect(r.stdout).to match(/#{node_names_all}/) }
   end
 
   it 'should reconstruct the node list from a previous compile failure when using --last' do
     env_path = File.join(testdir_broken_test, 'environments')
-    on(master, puppet("preview --preview_environment test #{node_name} --environmentpath #{env_path}"),
+    on(master, puppet("preview --preview_environment test #{node_names_cli.join(' ')} --nodes #{node_names_filename} --environmentpath #{env_path}"),
       :acceptable_exit_codes => [3]) { |r| }
     on(master, puppet("preview --last --view failed_nodes"),
-      {:catch_failures => true, :acceptable_exit_codes => [0]}) { |r| expect(r.stdout).to match(/#{node_name}/) }
+      {:catch_failures => true, :acceptable_exit_codes => [0]}) { |r| expect(r.stdout).to match(/#{node_names_all}/) }
   end
 
   it 'should produce overview including failed nodes from --last --view overview_json' do
     env_path = File.join(testdir_broken_test, 'environments')
-    on(master, puppet("preview --preview_environment test #{node_name} --environmentpath #{env_path}"),
+    on(master, puppet("preview --preview_environment test #{node_names_cli.join(' ')} --nodes #{node_names_filename} --environmentpath #{env_path}"),
       :acceptable_exit_codes => [3]) { |r| }
     on(master, puppet("preview --last --view overview_json"), {:catch_failures => true, :acceptable_exit_codes => [0]}) do |r|
       report = JSON.parse(r.stdout)
       expect(report['stats']).to be_a(Hash)
       expect(report['stats']['failures']).to be_a(Hash)
       expect(report['stats']['failures']['preview']).to be_a(Hash)
-      expect(report['stats']['failures']['preview']['total']).to eq(1)
+      expect(report['stats']['failures']['preview']['total']).to eq(node_names_all.length)
       expect(report['preview']).to be_a(Hash)
       expect(report['preview']['compilation_errors']).to be_an(Array)
-      expect(report['preview']['compilation_errors'].size).to be(1)
+      expect(report['preview']['compilation_errors'][0]['errors'].size).to be(node_names_all.length)
     end
   end
 
   it 'should --view diff_nodes' do
     env_path = File.join(testdir_simple, 'environments')
-    on master, puppet("preview --preview_environment test #{node_name} --environmentpath #{env_path} --view diff_nodes"),
+    on master, puppet("preview --preview_environment test #{node_names_cli.join(' ')} --nodes #{node_names_filename} --environmentpath #{env_path} --view diff_nodes"),
       :acceptable_exit_codes => [0] do |r|
-      expect(r.stdout).to match(/#{node_name}/)
+      expect(r.stdout).to match(/#{node_names_all}/)
     end
   end
 
   it 'should output nothing from --view failed_nodes with no failed nodes' do
     env_path = File.join(testdir_simple, 'environments')
-    on master, puppet("preview --preview_environment test #{node_name} --environmentpath #{env_path} --view failed_nodes"),
+    on master, puppet("preview --preview_environment test #{node_names_cli.join(' ')} --nodes #{node_names_filename} --environmentpath #{env_path} --view failed_nodes"),
       {:acceptable_exit_codes => [0]} do |r|
       expect(r.exit_code).to be_zero
       expect(r.stdout).to be_empty
@@ -288,10 +289,10 @@ EOS
 
   it 'should show the error and the failed nodes with --view failed_nodes' do
     env_path = File.join(testdir_broken_test, 'environments')
-    on master, puppet("preview --preview_environment test #{node_name} --environmentpath #{env_path} --view failed_nodes"),
+    on master, puppet("preview --preview_environment test #{node_names_cli.join(' ')} --nodes #{node_names_filename} --environmentpath #{env_path} --view failed_nodes"),
       :acceptable_exit_codes => [3] do |r|
       expect(r.stderr).to match(/Illegal attempt to assign to 'a Name'/)
-      expect(r.stdout).to match(/#{node_name}/)
+      expect(r.stdout).to match(/#{node_names_all}/)
     end
   end
 
@@ -304,7 +305,7 @@ EOS
 
   it 'should exit with 2 when baseline compilation fails' do
     env_path = File.join(testdir_broken_production, 'environments')
-    on master, puppet("preview --preview_environment test #{node_name} --environmentpath #{env_path}"),
+    on master, puppet("preview --preview_environment test #{node_names_cli.join(' ')} --nodes #{node_names_filename} --environmentpath #{env_path}"),
                 :acceptable_exit_codes => [2] do |r|
       expect(r.stderr).not_to    be_empty
     end
@@ -312,7 +313,7 @@ EOS
 
   it 'should exit with 3 when preview compilation fails' do
     env_path = File.join(testdir_broken_test, 'environments')
-    on master, puppet("preview --preview_environment test #{node_name} --environmentpath #{env_path}"),
+    on master, puppet("preview --preview_environment test #{node_names_cli.join(' ')} --nodes #{node_names_filename} --environmentpath #{env_path}"),
                 :acceptable_exit_codes => [3] do |r|
       expect(r.stderr).not_to    be_empty
     end
@@ -320,49 +321,49 @@ EOS
 
   it 'should exit with 4 when -assert equal is used and catalogs are not equal' do
     env_path = File.join(testdir_simple, 'environments')
-    on master, puppet("preview --preview_environment test --assert equal --migrate 3.8/4.0 #{node_name} --environmentpath #{env_path}"),
+    on master, puppet("preview --preview_environment test --assert equal --migrate 3.8/4.0 #{node_names_cli.join(' ')} --nodes #{node_names_filename} --environmentpath #{env_path}"),
                 :acceptable_exit_codes => [4]
   end
 
   it 'should exit with 4 when -assert equal is used and catalogs are compliant' do
     env_path = File.join(testdir_simple, 'environments')
-    on master, puppet("preview --preview_environment compliant --assert equal --migrate 3.8/4.0 nonesuch --environmentpath #{env_path}"),
+    on master, puppet("preview --preview_environment compliant --assert equal --migrate 3.8/4.0 #{node_names_cli.join(' ')} --nodes #{node_names_filename} --environmentpath #{env_path}"),
       :acceptable_exit_codes => [4]
   end
 
   it 'should exit with 0 when -assert compliant is used and catalogs are compliant' do
     env_path = File.join(testdir_simple, 'environments')
-    on master, puppet("preview --preview_environment compliant --assert compliant --migrate 3.8/4.0 nonesuch --environmentpath #{env_path}"),
+    on master, puppet("preview --preview_environment compliant --assert compliant --migrate 3.8/4.0 #{node_names_cli.join(' ')} --nodes #{node_names_filename} --environmentpath #{env_path}"),
       :acceptable_exit_codes => [0]
   end
 
   it 'should exit with 0 when -assert equal is used and catalogs are equal due to exclude' do
     env_path = File.join(testdir_simple, 'environments')
-    on master, puppet("preview --preview_environment compliant --assert equal --excludes #{testdir_simple}/files/excludes.json --migrate 3.8/4.0 nonesuch --environmentpath #{env_path}"),
+    on master, puppet("preview --preview_environment compliant --assert equal --excludes #{testdir_simple}/files/excludes.json --migrate 3.8/4.0 #{node_names_cli.join(' ')} --nodes #{node_names_filename} --environmentpath #{env_path}"),
       :acceptable_exit_codes => [0]
   end
 
   it 'should exit with 0 when -assert equal is used and catalogs are equal due to exclude with no title' do
     env_path = File.join(testdir_simple, 'environments')
-    on master, puppet("preview --preview_environment compliant --assert equal --excludes #{testdir_simple}/files/excludes_wo_title.json --migrate 3.8/4.0 nonesuch --environmentpath #{env_path}"),
+    on master, puppet("preview --preview_environment compliant --assert equal --excludes #{testdir_simple}/files/excludes_wo_title.json --migrate 3.8/4.0 #{node_names_cli.join(' ')} --nodes #{node_names_filename} --environmentpath #{env_path}"),
       :acceptable_exit_codes => [0]
   end
 
   it 'should exit with 0 when -assert equal is used and catalogs are equal due to exclude with no attributes' do
     env_path = File.join(testdir_simple, 'environments')
-    on master, puppet("preview --preview_environment compliant --assert equal --excludes #{testdir_simple}/files/excludes_wo_attributes.json --migrate 3.8/4.0 nonesuch --environmentpath #{env_path}"),
+    on master, puppet("preview --preview_environment compliant --assert equal --excludes #{testdir_simple}/files/excludes_wo_attributes.json --migrate 3.8/4.0 #{node_names_cli.join(' ')} --nodes #{node_names_filename} --environmentpath #{env_path}"),
       :acceptable_exit_codes => [0]
   end
 
   it 'should exit with 0 when -assert equal is used and catalogs are equal due to exclude with neither title nor attributes' do
     env_path = File.join(testdir_simple, 'environments')
-    on master, puppet("preview --preview_environment compliant --assert equal --excludes #{testdir_simple}/files/excludes_wo_title_and_attributes.json --migrate 3.8/4.0 nonesuch --environmentpath #{env_path}"),
+    on master, puppet("preview --preview_environment compliant --assert equal --excludes #{testdir_simple}/files/excludes_wo_title_and_attributes.json --migrate 3.8/4.0 #{node_names_cli.join(' ')} --nodes #{node_names_filename} --environmentpath #{env_path}"),
       :acceptable_exit_codes => [0]
   end
 
   it 'should exit with 5 when -assert compliant is used and preview is not compliant' do
     env_path = File.join(testdir_simple, 'environments')
-    on master, puppet("preview --preview_environment test --assert compliant --migrate 3.8/4.0 nonesuch --environmentpath #{env_path}"),
+    on master, puppet("preview --preview_environment test --assert compliant --migrate 3.8/4.0 #{node_names_cli.join(' ')} --nodes #{node_names_filename} --environmentpath #{env_path}"),
                 :acceptable_exit_codes => [5]
   end
 
@@ -370,7 +371,7 @@ EOS
 
     it 'accepts --migrate 3.8/4.0' do
       env_path = File.join(testdir_simple, 'environments')
-      on master, puppet("preview --preview_environment test --migrate 3.8/4.0 #{node_name} --environmentpath #{env_path}"),
+      on master, puppet("preview --preview_environment test --migrate 3.8/4.0 #{node_names_cli.join(' ')} --nodes #{node_names_filename} --environmentpath #{env_path}"),
                   { :catch_failures => true } do |r|
         expect(r.exit_code).to be_zero
       end
@@ -379,7 +380,7 @@ EOS
 
     it 'errors with exit 1 on --migrate 3.8/4.0' do
       env_path = File.join(testdir_simple, 'environments')
-      on master, puppet("preview --preview_environment test --migrate 3.8/4.0 #{node_name} --environmentpath #{env_path}"),
+      on master, puppet("preview --preview_environment test --migrate 3.8/4.0 #{node_names_cli} --nodes #{node_names_filename} --environmentpath #{env_path}"),
                   :acceptable_exit_codes => [1]
     end
   end


### PR DESCRIPTION
This change adds multiple nodes to most of the preview runs that make
sense in the existing tests. We specify nodes on the command line and
via a file using --nodes.
**Please note the two TODO: comments**. This behavior seems unexpected to
me.
Some of the code herein is quite repetitive, suggest ticketing to clean
up and/or dry-out in next commit. Could be cleaned up in this PR with
some effort, probably only useful if wanting to get this in prior to
sprint-end.
