### PR TITLE
(PRE-78) Make attributes with Set values be presented as lists

### DIFF
--- a/spec/unit/catalog_delta_model_spec.rb
+++ b/spec/unit/catalog_delta_model_spec.rb
@@ -524,6 +524,20 @@ describe 'CatalogDelta' do
     end
   end
 
+  it 'converts the value of attributes that use Set semantics into an array' do
+    pv = preview_hash
+    pv['resources'][1]['parameters']['before'] = %w(c b)
+    delta = CatalogDelta.new(baseline_hash, pv, options, timestamp)
+    crs = delta.conflicting_resources
+    expect(crs.size).to eq(1)
+    cas = crs[0].conflicting_attributes
+    expect(cas.size).to eq(1)
+    ca = cas[0]
+    expect(ca.baseline_value).to be_an(Array)
+    expect(ca.preview_value).to be_an(Array)
+    JSON::Validator.validate!(catalog_delta_schema, JSON.dump(delta.to_hash))
+  end
+
   it 'allows variables that have Set semantics to be strings' do
     pv = preview_hash
     pv['resources'][3]['parameters'] =  {


### PR DESCRIPTION
The Ruby JSON implementation in use by preview does not present a
ruby Set as a JSON list. Instead, the class name and instance id
of the Set is printed. This data is not useful in a catalog diff.

This commit ensures that all such Set instances are converted into
sorted Arrays once the delta calculation has been made, thus ensuring
that they will be output as JSON lists in when the delta is printed.
