### PR TITLE
Update metadata and CHANGELOG for 2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+##2015-08-04 - Release 2.0.2
+###Summary
+
+This release includes several bug fixes.
+
+Previously when running with the Puppet 4x parser, --view diff_nodes would produce an incorrect list of nodes both with --last and without. That bug has been fixed and now the correct list of nodes will be printed.
+
+With previous versions of PuppetDB, catalog_preview used its own variant of the fact terminus. With the release of PuppetDB 3, catalog_preview needs to use PuppetDB's fact terminus instead which meant it was broken with PuppetDB 3. That bug has been fixed and catalog_preview will now adjust accordingly based on the version of PuppetDB being used.
+
+Previously, catalog_preview diffs were not displaying tag parameters in a human readable format. It would just display a Ruby object reference. Now that bug has been fixed and the tags are displayed properly.
+
 ##2015-07-14 - Release 2.0.1
 ###Summary
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-catalog_preview",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "author": "puppetlabs",
   "summary": "PE-only module providing catalog preview and migration features",
   "license": "PuppetLabs-Enterprise",
@@ -74,11 +74,11 @@
   "requirements": [
     {
       "name": "pe",
-      "version_requirement": ">= 3.8.0"
+      "version_requirement": ">= 3.8.0 < 2015.3.0"
     },
     {
       "name": "puppet",
-      "version_requirement": ">= 3.8.0"
+      "version_requirement": ">= 3.8.0 < 5.0.0"
     }
   ],
   "dependencies": [


### PR DESCRIPTION
Update the metadata.json and CHANGELOG.md for the 2.0.2 relase of
catalog_preview.
