### PR TITLE
(maint) fix pre-80 tests for debian distros

### DIFF
--- a/spec/integration/preview_spec.rb
+++ b/spec/integration/preview_spec.rb
@@ -216,7 +216,7 @@ EOS
 
   # TODO: this requires use of run_as_previewser command to be enclosed in quotes.
   #   nasty.  refactor me into a method string replacement
-  let(:run_as_previewser) {'runuser -l previewser -c '}
+  let(:run_as_previewser) {'su previewser --command '}
   let(:puppet_path) {on(master, 'which puppet').stdout.chomp}
   context 'when comparing simple catalogs' do
     it 'as root, should exit with 0 and produce json logfiles' do


### PR DESCRIPTION
This change ensures we can run commands as a user on any posix distro.
Prior to this the non-root tests would fail on some platforms.
