### PR TITLE
(maint) fix non-root tests on PE

### DIFF
--- a/spec/spec_helper_integration.rb
+++ b/spec/spec_helper_integration.rb
@@ -382,5 +382,8 @@ HERE
     else
       puppet_module_install(:source => proj_root, :module_name => 'preview', :target_module_path => target_module_path)
     end
+    # ensure non-root users can access the module in PE 3x:
+    on master, "mkdir -p /usr/share/puppet/modules && ln -s #{target_module_path}/preview /usr/share/puppet/modules"
+
   end
 end


### PR DESCRIPTION
Prior to this fix, non-root users could not use the preview subcommand
as the module was not being installed in the correct place. Symbolic
linking it into the path for 3x and 2015.2 fixes these tests.
