### PR TITLE
(PRE-81) Add workaround to ensure that correct environment is used

### DIFF
--- a/lib/puppet/indirector/catalog/diff_compiler.rb
+++ b/lib/puppet/indirector/catalog/diff_compiler.rb
@@ -161,6 +161,9 @@ class Puppet::Resource::Catalog::DiffCompiler < Puppet::Indirector::Code
         if options[:baseline_environment]
           # Switch the node's environment (it finds and instantiates the Environment)
           node.environment = options[:baseline_environment]
+
+          # Ugly workaround for PUP-5522
+          node.parameters['environment'] = node.environment.name
         end
         options[:back_channel][:baseline_environment] = node.environment
 
@@ -197,6 +200,9 @@ class Puppet::Resource::Catalog::DiffCompiler < Puppet::Indirector::Code
       Puppet::Util::Log.with_destination(preview_dest) do
 
         node.environment = options[:preview_environment]
+
+        # Ugly workaround for PUP-5522
+        node.parameters['environment'] = node.environment.name
 
         Puppet::Util::Profiler.profile(preview_dest, [:diff_compiler, :compile_preview, node.environment, node.name]) do
           # Switch the node's environment (it finds and instantiates the Environment)


### PR DESCRIPTION
The Puppet::Node does not change its 'environment' parameter when
the 'envirionment' attribute changes. This has been reported as
PUP-5522. This commit provides a workaround to ensure that the
catalog_preview works with versions where that fix isn't included.
