### PR TITLE
(PRE-82) Update docs and metadata for 2015.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ To get started, you'll need:
 
 As mentioned above, if you're performing a migration check, your current production environment should be configured to use the current, or Puppet 3, parser. Your preview environment should be pointed at a branch of your current environment and configured to use the future, or Puppet 4, parser. Configure which parser each environment uses via the [`parser`][parser_config_38] setting in each environment's `environment.conf`.
 
-Note that your PE version must be **less than** PE 2015.2 to use this tool for previewing a migration. Because PE 2015.2 contains only the "future" parser, if you are running 2015.2, no migration-specific check can be made.
+Note that your PE version must be **less than** PE 2015.2 to use this tool for previewing a migration. Because starting with 2015.2, PE contains only the "future" parser, if you are running 2015.2 or later, no migration-specific check can be made.
  
 ###Installation
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-catalog_preview",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "author": "puppetlabs",
   "summary": "PE-only module providing catalog preview and migration features",
   "license": "PuppetLabs-Enterprise",
@@ -74,7 +74,7 @@
   "requirements": [
     {
       "name": "pe",
-      "version_requirement": ">= 3.8.0 < 2015.3.0"
+      "version_requirement": ">= 3.8.0 < 2015.4.0"
     },
     {
       "name": "puppet",


### PR DESCRIPTION
Prior to this commit, the metadata for preview suggested that PE
2015.3 was not supported. To prepare for the new release, bump
the upper PE limit and the catalog preview version in the module
metadata and make one small change to the README.
