### PR TITLE
(maint) refactor gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,6 @@ def location_for(place, fake_version = nil)
   end
 end
 
-gem 'rubocop',                   :require => false
-
 group :system_tests do
   gem 'rake'
   gem 'beaker'
@@ -33,6 +31,7 @@ group :development do
   gem 'travis-lint'
   gem 'puppet-blacksmith'
   gem 'guard-rake'
+  gem 'rubocop',                 :require => false
 end
 
 local_gemfile = "#{__FILE__}.local"


### PR DESCRIPTION
```
This change solidifies our use of bundler groups in the single Gemfile for
reduction of the bundled gem dependencies for dev,unit tests and
integration tests.  This should save time in the unit and integration
jobs.
This change also adds a user/global gemfile merge which allows for easy
addition of things like pry and other debugging gems from a central
location for all projects. 

[skip ci]
```
