### PR TITLE
(PRE-66) Make it possible to produce diff using only one environment

### DIFF
--- a/lib/puppet/application/preview.rb
+++ b/lib/puppet/application/preview.rb
@@ -208,9 +208,9 @@ class Puppet::Application::Preview < Puppet::Application
         last
         @exit_code = 0
       else
-        unless options[:preview_environment]
-          raise UsageError, 'No --preview_environment given - cannot compile and produce a diff when only"\
-                " the environment of the node is known'
+        unless options[:preview_environment] || options[:migrate]
+          raise UsageError, 'Neither --preview_environment or --migrate given - cannot compile and produce a diff "\
+                "when only the environment of the node is known'
         end
 
         if options[:diff_string_numeric] && !options[:migration_checker] && !options[:migrate] == MIGRATION_3to4
@@ -273,7 +273,7 @@ class Puppet::Application::Preview < Puppet::Application
         catalog_delta = compile_diff(node, timestamp)
 
         baseline_env = options[:back_channel][:baseline_environment]
-        preview_env = options[:preview_environment]
+        preview_env = options[:back_channel][:preview_environment]
         if baseline_env.to_s == preview_env.to_s && !options[:migrate]
           raise UsageError, "The baseline and preview environments for node '#{node}' are the same: '#{baseline_env}'"
         end
@@ -360,7 +360,7 @@ class Puppet::Application::Preview < Puppet::Application
         compile_info = {
           :exit_code => @exit_code,
           :baseline_environment => options[:back_channel][:baseline_environment].to_s,
-          :preview_environment => options[:preview_environment],
+          :preview_environment => options[:back_channel][:preview_environment].to_s,
           :time => timestamp
         }
         of.write(PSON::pretty_generate(compile_info))

--- a/lib/puppet/application/preview.rb
+++ b/lib/puppet/application/preview.rb
@@ -640,11 +640,17 @@ Output:
   end
 
   def read_json(node, type)
-    json = File.read(options[type])
-    if json.nil? || json.empty?
-      raise Puppet::Error.new("Output for node #{node} is invalid - use --clean and/or recompile")
+    filename = options[type]
+    json = nil
+    source = File.read(filename)
+    unless source.nil? || source.empty?
+      begin
+        json = JSON.load(source)
+      rescue JSON::ParserError
+      end
     end
-    JSON.load(json)
+    raise Puppet::Error, "Output for node #{node} is invalid - use --clean and/or recompile" if json.nil?
+    json
   end
 
   def generate_last_overview

--- a/lib/puppet/application/preview.rb
+++ b/lib/puppet/application/preview.rb
@@ -103,8 +103,7 @@ class Puppet::Application::Preview < Puppet::Application
   option('--clean')
 
   def help
-    path = ::File.expand_path( '../../../puppet_x/puppetlabs/preview/api/documentation/preview-help.md', __FILE__)
-    Puppet::FileSystem.read(path)
+    Puppet::FileSystem.read(api_path('documentation', 'preview-help.md'))
   end
 
   # Sets up the 'node_cache_terminus' default to use the Write Only Yaml terminus :write_only_yaml.

--- a/lib/puppet_x/puppetlabs/preview/api/documentation/preview-help.md
+++ b/lib/puppet_x/puppetlabs/preview/api/documentation/preview-help.md
@@ -3,8 +3,10 @@ puppet-preview(8) -- Puppet catalog preview compiler
 
 SYNOPSIS
 --------
-Compiles two catalogs for one or more nodes: one catalog in the baseline environment and one in a preview environment and computes a diff between the two. Produces the two catalogs, the diff, and
-the logs from each compilation for each node and then summaries/aggregates and correlates found issues in various views of the produced information.
+Compiles two catalogs for one or more nodes and computes a diff between the two. The catalogs may
+reflect different environments, be compiled with different compilers, or both. Produces the two
+catalogs, the diff, and the logs from each compilation for each node and then summaries/aggregates
+and correlates found issues in various views of the produced information.
 
 USAGE
 -----
@@ -23,7 +25,7 @@ puppet preview [
     [-vd|--verbose_diff]
     [--trusted]
     [--baseline_environment <ENV-NAME> | --be <ENV-NAME>]
-    --preview_environment <ENV-NAME> | --pe <ENV-NAME>
+    [--preview_environment <ENV-NAME> | --pe <ENV-NAME>]
     <NODE-NAME>+ | --nodes <FILE> <NODE_NAME>*
   ]|[--schema catalog|catalog_delta|excludes|log|help]
    |[-h|--help]
@@ -36,15 +38,16 @@ This command compiles, compares, and asserts a baseline catalog and a preview ca
 for one or several node(s) that has previously requested a catalog from a puppet master
 (thereby making the node's facts available). The compilation of the baseline catalog takes
 place in the environment configured for each given node (optionally overridden
-with '--baseline_environment'). The compilation of the preview takes place in the environment
-designated by '--preview_environment'.
+with '--baseline_environment'). The compilation of the preview takes place in the same environment
+or in the environment designated by '--preview_environment'. Using the same environment is only
+meaningful when the compiler used for producing the baseline catalog is different from the one
+used when producing the preview catalog (see option --migrate below).
 
 If '--baseline_environment' is set, a node will first be configured as directed by
 an ENC, the environment is then switched to the '--baseline_environment'.
-The '--baseline_environment' option is intended to aid when changing code in the
-preview environment (for the purpose of making it work with the future parser) while
-the original environment is unchanged and is configured with the 3.x current parser
-(i.e. what is in 'production').
+The '--preview_environment' option is intended to aid when changing code (for the purpose
+of making it work with the future parser) while the original environment is unchanged and
+is configured with the 3.x current parser (i.e. what is in 'production').
 If the intent is to make backwards compatible changes in the preview
 environment (i.e. changes that work for both parsers) it is of value to have yet another
 environment configured for current (3.x) parser where the same code as in the preview
@@ -52,7 +55,8 @@ environment is checked out. It is then simple to diff between compilations in an
 environments without having to modify the environment assigned by the ENC. All other
 assignments made by the ENC are unchanged.
 
-By default the command outputs a summary report of the difference between the two catalogs on 'stdout' if the command operates on a single node, and outputs an summary per node when the
+By default the command outputs a summary report of the difference between the two catalogs on 'stdout'
+if the command operates on a single node, and outputs an summary per node when the
 command operates on multiple nodes. The output for a single node can be changed with '--view'
 to instead view one of the catalogs, the diff, or one of the compilation logs. For
 multiple nodes --view overview produces and overview of aggregated and correlated
@@ -66,12 +70,15 @@ When the preview compilation is performed, it is possible to turn on extra
 migration validation using '--migrate 3.8/4.0'. This will turn on extra validations
 of future compatibility flagging puppet code that needs to be reviewed. This
 feature was introduced to help with the migration from puppet 3.x to puppet 4.x.
-and requires that the '--preview_envenvironment' references an environment configured
-to use the future parser in its environment.conf.
+If the '--preview_environment' is used, then it must reference an environment configured
+to use the future parser in its environment.conf. If no preview environment has been designated,
+then the same environment will be compiled twice and the use of the future parser will be enforced
+during the second compilation.
 
 The wanted kind of migration checks to perform must be given with the '--migrate' option.
 This version of preview support the migration kind '3.8/4.0'. The version of Puppet used
-with this version of preview must also support this migration kind (which Puppet does between the versions >= 3.8.0 and < 4.0.0 does). Newer versions of Puppet may contain additional
+with this version of preview must also support this migration kind (which Puppet does between the
+versions >= 3.8.0 and < 4.0.0 does). Newer versions of Puppet may contain additional
 new migration strategies.
 
 All output (except the summary/status and overview reports intended for human use) is written in
@@ -110,6 +117,7 @@ The 'compilation_info.json' is a catalog preview internal file.
 
 SETUP
 -----
+Using two environments:
 * Include this (the catalog-preview) module in the puppet configuration
 * Create an environment in which the preview compilation should take place (the version
   of the source and the version of the environment configuration you want to diff against
@@ -122,6 +130,16 @@ SETUP
   for information about the parser setting).
 * Run preview for one or multiple nodes that have already checked in with the master
 * Slice and dice the information to find problems
+
+Using only one environment (limited to --migrate '3.8/4.0'):
+* Include this (the catalog-preview) module in the puppet configuration
+* When using preview to migrate from 3.8 to 4.0 configure the baseline environment to use
+  the current parser. (This is specific to puppet versions >= 3.8 <= 4.0.0), see:
+    https://docs.puppetlabs.com/puppet/3.8/reference/config_file_environment.html#parser
+  for information about the parser setting).
+* Run preview for one or multiple nodes that have already checked in with the master
+* Slice and dice the information to find problems
+
 
 OPTIONS
 -------
@@ -297,6 +315,10 @@ resources of File type using 'jq' to filter the output (the command is given as 
 
     puppet preview --pe future_production --view diff mynode 
     | jq -f '.conflicting_resources | map(select(.type == "File"))'
+
+To perform a full migration preview for multiple nodes using only one environment:
+
+    puppet preview --migrate 3.8/4.0 --view overview mynode1 mynode2 mynode3
 
 View the catalog schema:
 

--- a/lib/puppet_x/puppetlabs/preview/api/documentation/preview-help.md
+++ b/lib/puppet_x/puppetlabs/preview/api/documentation/preview-help.md
@@ -45,9 +45,9 @@ used when producing the preview catalog (see option --migrate below).
 
 If '--baseline_environment' is set, a node will first be configured as directed by
 an ENC, the environment is then switched to the '--baseline_environment'.
-The '--preview_environment' option is intended to aid when changing code (for the purpose
-of making it work with the future parser) while the original environment is unchanged and
-is configured with the 3.x current parser (i.e. what is in 'production').
+The '--basline_environment' and '--preview_environment' options are intended to aid when changing
+code (for the purpose of making it work with the future parser) while the original environment is
+unchanged and is configured with the 3.x current parser (i.e. what is in 'production').
 If the intent is to make backwards compatible changes in the preview
 environment (i.e. changes that work for both parsers) it is of value to have yet another
 environment configured for current (3.x) parser where the same code as in the preview
@@ -56,7 +56,7 @@ environments without having to modify the environment assigned by the ENC. All o
 assignments made by the ENC are unchanged.
 
 By default the command outputs a summary report of the difference between the two catalogs on 'stdout'
-if the command operates on a single node, and outputs an summary per node when the
+if the command operates on a single node, and outputs a summary per node when the
 command operates on multiple nodes. The output for a single node can be changed with '--view'
 to instead view one of the catalogs, the diff, or one of the compilation logs. For
 multiple nodes --view overview produces and overview of aggregated and correlated

--- a/spec/fixtures/etc/puppet/environments/env4x/environment.conf
+++ b/spec/fixtures/etc/puppet/environments/env4x/environment.conf
@@ -1,0 +1,2 @@
+[main]
+parser = future

--- a/spec/fixtures/etc/puppet/environments/env4x/manifests/site.pp
+++ b/spec/fixtures/etc/puppet/environments/env4x/manifests/site.pp
@@ -1,0 +1,7 @@
+define x($y) {
+  notify { number: message => $y }
+}
+
+node default {
+  x { test: y => 0777 }
+}

--- a/spec/fixtures/etc/puppet/environments/production/manifests/site.pp
+++ b/spec/fixtures/etc/puppet/environments/production/manifests/site.pp
@@ -1,0 +1,7 @@
+define x($y) {
+  notify { number: message => $y }
+}
+
+node default {
+  x { test: y => 0777 }
+}

--- a/spec/fixtures/etc/puppet/puppet.conf
+++ b/spec/fixtures/etc/puppet/puppet.conf
@@ -1,0 +1,3 @@
+[main]
+environmentpath = $confdir/environments
+environment_timeout = unlimited

--- a/spec/integration/preview_spec.rb
+++ b/spec/integration/preview_spec.rb
@@ -524,6 +524,20 @@ EOS
         expect(r.exit_code).to be_zero
       end
     end
+
+    it 'accepts --migrate 3.8/4.0 and no --preview_environment' do
+      env_path = File.join(testdir_simple, 'environments')
+      on master, puppet("preview --migrate 3.8/4.0 #{node_names_cli.join(' ')} --nodes #{node_names_filename} --environmentpath #{env_path}"),
+         { :catch_failures => true } do |r|
+        expect(r.exit_code).to be_zero
+      end
+    end
+
+    it 'errors with exit 1 when neither --migrate nor --preview_environment is given' do
+      env_path = File.join(testdir_simple, 'environments')
+      on master, puppet("preview #{node_names_cli.join(' ')} --nodes #{node_names_filename} --environmentpath #{env_path}"),
+         :acceptable_exit_codes => [1]
+    end
   else
 
     it 'errors with exit 1 on --migrate 3.8/4.0' do

--- a/spec/unit/preview_spec.rb
+++ b/spec/unit/preview_spec.rb
@@ -242,17 +242,18 @@ Edges:
   Added.........: 0
 
 Output:
-  For node......: /dev/null/preview/
+  For node......: /dev/null/preview/compliant.example.com
 
 Catalogs for 'compliant.example.com' are not equal but compliant.
         TEXT
         preview.options[:view] = :summary
-        expect{ preview.view(diff_catalog)}.to output(expected_summary).to_stdout
+        preview.latest_catalog_delta = diff_catalog
+        expect { preview.view }.to output(expected_summary).to_stdout
       end
 
       it "'status' outputs the compliance status of the node" do
         preview.options[:view] = :status
-        expect{ preview.view}.to output("Catalogs for 'compliant.example.com' are not equal but compliant.\n").to_stdout
+        expect { preview.view }.to output("Catalogs for 'compliant.example.com' are not equal but compliant.\n").to_stdout
       end
     end
   end


### PR DESCRIPTION
This PR makes it is possible to generate this diff by compiling the same environment twice, switching the parser from 'current' to 'future' between the compiles. It also improves how unit tests interface with the application, fixes some style related issues, and some minor bugs.