### PR TITLE
(PRE-72) Use process owner as default for Puppet user and group

### DIFF
--- a/lib/puppet/application/preview.rb
+++ b/lib/puppet/application/preview.rb
@@ -748,6 +748,12 @@ Output:
   def setup
     raise Puppet::Error.new('Puppet preview is not supported on Microsoft Windows') if Puppet.features.microsoft_windows?
 
+    # Make process owner current user unless process owner is 'root'
+    unless Puppet.features.root?
+      Puppet[:user] = Etc.getpwuid(Process.uid).name
+      Puppet[:group] = Etc.getgrgid(Process.gid).name
+    end
+
     setup_logs
 
     exit(Puppet.settings.print_configs ? 0 : 1) if Puppet.settings.print_configs?


### PR DESCRIPTION
Puppet versions < 4.0 will make an attempt to change the user and group
of a log destination file to 'puppet'. This fails unless the user has
root privileges. This commit changes the catalog_preview command so that
it detects when the process owner is non-root user and then sets the
`Puppet[:user]` and `Puppet[:group]` to values that correspond to the
`uid` and `gid` of the process owner, thus preventing permission errors
further on.