### PR TITLE
(PRE-91) Add flag to suppress value vs [value] conflicts

### DIFF
--- a/lib/puppet/application/preview.rb
+++ b/lib/puppet/application/preview.rb
@@ -81,6 +81,8 @@ class Puppet::Application::Preview < Puppet::Application
 
   option('--[no-]diff-string-numeric', '--diff_string_numeric')
 
+  option('--[no-]diff-array-value')
+
   option('--trusted') do |_|
     options[:trusted] = true
   end
@@ -222,6 +224,15 @@ class Puppet::Application::Preview < Puppet::Application
           # the string/numeric diff is ignored when migrating from 3 to 4
           options[:diff_string_numeric] = options[:migrate] != MIGRATION_3to4
         end
+
+        if options.include?(:diff_array_value)
+          if options[:migrate] != MIGRATION_3to4
+            raise UsageError, '--diff-array-value can only be used in combination with --migrate 3.8/4.0'
+          end
+        else
+          options[:diff_array_value] = true # this is the default
+        end
+
         compile
 
         view

--- a/lib/puppet_x/puppetlabs/preview/api/documentation/preview-help.md
+++ b/lib/puppet_x/puppetlabs/preview/api/documentation/preview-help.md
@@ -16,7 +16,7 @@ puppet preview [
     [-d|--debug]
     [-l|--last]
     [--clean]
-    [-m <MIGRATION>|--migrate <MIGRATION> [--[no-]diff-string-numeric]]
+    [-m <MIGRATION>|--migrate <MIGRATION> [--[no-]diff-string-numeric] [--[no-]diff-array-value]]
     [--preview-outputdir <PATH-TO-OUTPUT-DIR>]
     [--[no-]skip-tags]
     |--excludes <PATH-TO-EXCLUSIONS-FILE>]
@@ -171,6 +171,13 @@ Note that all settings (such as 'log_level') affect both compilations.
   difference in type will be ignored. This option can only be combined with `--migrate 3.8/4.0` and
   will then default to `--no-diff-string-numeric`. The behavior for other types of conversions is
   always equivalent to `--diff-string-numeric`
+
+* --\[no-\]diff-array-value
+  A value in the baseline catalog that is compared to a one element array containing that value in
+  the preview catalog is normally considered a conflict. Using `--no-diff-array-value` will prevent
+  this conflict from being reported. This option can only be combined with `--migrate 3.8/4.0` and
+  will default to `--diff-array-value`. The behavior for other types of conversions is always
+  equivalent to `--diff-array-value`.
 
 * --excludes <FILE>
   Adds resource diff exclusion of specified attributes to prevent them from being included

--- a/lib/puppet_x/puppetlabs/preview/api/schemas/catalog-delta.json
+++ b/lib/puppet_x/puppetlabs/preview/api/schemas/catalog-delta.json
@@ -129,6 +129,10 @@
             "type": "boolean",
             "description": "This delta was produced with tags being ignored"
         },
+        "array_value_diff_ignored": {
+            "type": "boolean",
+            "description": "This delta was produced considering a value equal to a one element array containing that value"
+        },
         "string_numeric_diff_ignored": {
             "type": "boolean",
             "description": "This delta was produced considering strings and numbers equal if their numeric representation is the same"

--- a/spec/unit/catalog_delta_model_spec.rb
+++ b/spec/unit/catalog_delta_model_spec.rb
@@ -636,6 +636,16 @@ describe 'CatalogDelta' do
     JSON::Validator.validate!(catalog_delta_schema, JSON.dump(delta.to_hash))
   end
 
+  it 'ignores both string/int differences and array[value]/value differences when --migration MIGRATION is used with --no-diff-array-value' do
+    pv = preview_hash
+    pv['resources'][1]['parameters']['mol'] = [42]
+    delta = CatalogDelta.new(baseline_hash, pv, options.merge(:migration_checker => true, :diff_array_value => false), timestamp)
+    expect(delta.preview_equal?).to be(true)
+    expect(delta.preview_compliant?).to be(true)
+    expect(delta.array_value_diff_ignored?).to be(true)
+    JSON::Validator.validate!(catalog_delta_schema, JSON.dump(delta.to_hash))
+  end
+
   it 'detects array[value]/value differences when --migration MIGRATION is used with --diff-array-value' do
     pv = preview_hash
     pv['resources'][1]['parameters']['mol'] = ['42']

--- a/spec/unit/catalog_delta_model_spec.rb
+++ b/spec/unit/catalog_delta_model_spec.rb
@@ -626,6 +626,53 @@ describe 'CatalogDelta' do
     expect(delta.string_numeric_diff_ignored?).to be(false)
   end
 
+  it 'ignores array[value]/value differences when --migration MIGRATION is used with --no-diff-array-value' do
+    pv = preview_hash
+    pv['resources'][1]['parameters']['mol'] = ['42']
+    delta = CatalogDelta.new(baseline_hash, pv, options.merge(:migration_checker => true, :diff_array_value => false), timestamp)
+    expect(delta.preview_equal?).to be(true)
+    expect(delta.preview_compliant?).to be(true)
+    expect(delta.array_value_diff_ignored?).to be(true)
+    JSON::Validator.validate!(catalog_delta_schema, JSON.dump(delta.to_hash))
+  end
+
+  it 'detects array[value]/value differences when --migration MIGRATION is used with --diff-array-value' do
+    pv = preview_hash
+    pv['resources'][1]['parameters']['mol'] = ['42']
+    delta = CatalogDelta.new(baseline_hash, pv, options.merge(:migration_checker => true, :diff_array_value => true), timestamp)
+    expect(delta.preview_equal?).to be(false)
+    expect(delta.preview_compliant?).to be(false)
+    expect(delta.array_value_diff_ignored?).to be(false)
+    expect(delta.conflicting_resource_count).to eq(1)
+    expect(delta.conflicting_resources).to contain_exactly(be_a(ResourceConflict))
+    conflict = delta.conflicting_resources[0]
+    expect(conflict.type).to eq('File')
+    expect(conflict.title).to eq('/tmp/bartest')
+    expect(conflict.missing_attribute_count).to eq(0)
+    expect(conflict.added_attribute_count).to eq(0)
+    expect(conflict.conflicting_attribute_count).to eq(1)
+    expect(conflict.conflicting_attributes).to contain_exactly(be_a(AttributeConflict))
+    attr = conflict.conflicting_attributes[0]
+    expect(attr.name).to eq('mol')
+    expect(attr.baseline_value).to eq('42')
+    expect(attr.preview_value).to eq(['42'])
+    JSON::Validator.validate!(catalog_delta_schema, JSON.dump(delta.to_hash))
+  end
+
+  it 'ignores setting of --diff-array-value unless --migration MIGRATION is used' do
+    pv = preview_hash
+    pv['resources'][1]['parameters']['mol'] = ['42']
+    delta = CatalogDelta.new(baseline_hash, pv, options.merge(:migration_checker => false, :diff_array_value => true), timestamp)
+    expect(delta.preview_equal?).to be(false)
+    expect(delta.preview_compliant?).to be(false)
+    expect(delta.array_value_diff_ignored?).to be(false)
+
+    delta = CatalogDelta.new(baseline_hash, pv, options.merge(:migration_checker => false, :diff_array_value => false), timestamp)
+    expect(delta.preview_equal?).to be(false)
+    expect(delta.preview_compliant?).to be(false)
+    expect(delta.array_value_diff_ignored?).to be(false)
+  end
+
   it "reports string/int differences of the File 'mode' attribute regardless of migration_checker and diff_string_numeric flag" do
     pv = preview_hash
     pv['resources'][0]['parameters']['mode'] = 0600


### PR DESCRIPTION
This PR adds a new command line option `diff-array-value` which defaults to `true` (to retain backward compatibility) but can be turned off by using `--no-diff-array-value`. When it is turned off, a value in the baseline catalog will be considered equal to a one element array containing that value in the preview catalog.

The option can only be used together with `--migrate 3.8/4.0`.