### PR TITLE
(PRE-100) Fail compilation of nodes that doesn't have a valid factset

### DIFF
--- a/lib/puppet/application/preview.rb
+++ b/lib/puppet/application/preview.rb
@@ -329,7 +329,7 @@ class Puppet::Application::Preview < Puppet::Application
       unless result = Puppet::Resource::Catalog.indirection.find(node, options)
         # TODO: Should always produce a result and give better error depending on what failed
         #
-        raise GeneralError, "Could not compile catalogs for #{node}"
+        raise PuppetX::Puppetlabs::Preview::GeneralError, "Could not compile catalogs for #{node}"
       end
 
       # WRITE the two catalogs to output files

--- a/spec/unit/preview_spec.rb
+++ b/spec/unit/preview_spec.rb
@@ -300,5 +300,15 @@ Catalogs for 'compliant.example.com' are not equal but compliant.
       json_diff = JSON.parse(output_stream.string)
       expect(json_diff['conflicting_attribute_count']).to eql(2)
     end
+
+    it 'fails when no valid facts exist for a node' do
+      options[:preview_environment] = 'env4x'
+      options[:migrate] = '3.8/4.0'
+      options[:view] = :diff
+      options[:output_stream] = StringIO.new
+      Puppet::Node::Facts.any_instance.expects(:values).at_least_once.returns({})
+      expect{ preview.main }.to raise_error(PuppetX::Puppetlabs::Preview::GeneralError,
+        "Facts seems to be missing. No 'osfamily' fact found for node 'diff_compiler'")
+    end
   end
 end


### PR DESCRIPTION
Prior to this commit, a node that didn't have a valid factset would be
compiled anyway and cause a lot of errors. This made the output hard
to read. This commit ensures that the compilation of such nodes fails
with immediately with a single error indicating that facts seems to
be missing.