### PR TITLE
(maint) preserved hosts mode

### DIFF
--- a/spec/spec_helper_integration.rb
+++ b/spec/spec_helper_integration.rb
@@ -396,7 +396,7 @@ HERE
       puppet_module_install(:source => proj_root, :module_name => 'preview', :target_module_path => target_module_path)
     end
     # ensure non-root users can access the module in PE 3x:
-    on master, "mkdir -p /usr/share/puppet/modules && ln -s #{target_module_path}/preview /usr/share/puppet/modules"
+    on master, "mkdir -p /usr/share/puppet/modules && ln -s #{target_module_path}/preview /usr/share/puppet/modules", :accept_all_exit_codes => true
 
   end
 end


### PR DESCRIPTION
Previously, the acceptance test setup steps prevented re-running the
tests on provisioned hosts.  This change ensures idempotency in that
section of the setup, so one can run test(s) against previously
provisioned and installed hosts.
[skip ci]