### PR TITLE
(PRE-101) Add flag to control node list output

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,7 +496,12 @@ Specifies what will be output on stdout. Must be used with one of the following 
 * `compliant-nodes`: Outputs a list of nodes where catalogs where equal or compliant.
 * `none`: No output.
 
-The outputs `diff`, `baseline`, `preview`, `baseline-log`, `preview-log` only works for a single node. All `--view` options may be combined with the [`--last`](#--last) option (to avoid recompilation).
+The outputs `diff`, `baseline`, `preview`, `baseline-log`, `preview-log` only works for a single node.
+The output `overview` can be combined with the option [`--[no-]report-all`](#--[no-]report-all) option.
+All `--view` options may be combined with the [`--last`](#--last) option (to avoid recompilation).
+
+#####`--[no-]report-all`
+Controls if the `overview` report will contain a list of nodes that is limited to the ten nodes with the highest number of issues or if all nodes are included in the list. The default is to only include the top ten nodes. This option can only be used together with with `--view overview`.
 
 #####`--[no-]verbose-diff`
 

--- a/lib/puppet/application/preview.rb
+++ b/lib/puppet/application/preview.rb
@@ -83,6 +83,8 @@ class Puppet::Application::Preview < Puppet::Application
 
   option('--[no-]diff-array-value')
 
+  option('--[no-]report-all')
+
   option('--trusted') do |_|
     options[:trusted] = true
   end
@@ -231,6 +233,15 @@ class Puppet::Application::Preview < Puppet::Application
           end
         else
           options[:diff_array_value] = true # this is the default
+        end
+
+        if options.include?(:report_all)
+          unless options[:view] == :overview
+            raise UsageError, '--report-all can only be used in combination with --view overview'
+          end
+        else
+          # Default is to just report the top ten nodes
+          options[:report_all] = false
         end
 
         compile
@@ -653,7 +664,7 @@ Output:
   #
   def display_overview(overview, as_json)
     report = OverviewModel::Report.new(overview)
-    output_stream.puts(as_json ? report.to_json : report.to_s)
+    output_stream.puts(as_json ? report.to_json : report.to_text(!options[:report_all]))
   end
 
   def read_json(node, type)

--- a/lib/puppet_x/puppetlabs/preview/api/documentation/preview-help.md
+++ b/lib/puppet_x/puppetlabs/preview/api/documentation/preview-help.md
@@ -22,6 +22,7 @@ puppet preview [
     |--excludes <PATH-TO-EXCLUSIONS-FILE>]
     [--view summary|overview|overview-json|baseline|preview|diff|baseline-log|preview-log|none|
       failed-nodes|diff-nodes|compliant-nodes|equal-nodes]
+    [--[no-]report-all]
     [-vd|--[no-]verbose-diff]
     [--baseline-environment <ENV-NAME> | --be <ENV-NAME>]
     [--preview-environment <ENV-NAME> | --pe <ENV-NAME>]
@@ -40,7 +41,7 @@ Note that all settings (such as 'log_level') affect both compilations.
 * --assert equal | compliant
   Modifies the exit code to be 4 if catalogs are not equal and 5 if the preview
   catalog is not compliant instead of an exit with 0 to indicate that the preview run
-  was successful in itself. 
+  was successful in itself.
 
 * --baseline-environment <ENV-NAME> | --be <ENV-NAME>
   Makes the baseline compilation take place in the given <ENV-NAME>. This overrides
@@ -110,7 +111,7 @@ Note that all settings (such as 'log_level') affect both compilations.
 * --nodes <FILE>
   Specifies a file to read node-names from. If the file name is '-' file names are read
   from standard in. Each white-space separated sequence of characters is taken as a node name.
-  This may be combined with additional nodes given on the command line. Duplicate entries (in given  
+  This may be combined with additional nodes given on the command line. Duplicate entries (in given
   file, or on command line) are skipped.
 
 * --preview-environment <ENV-NAME> | --pe <ENV-NAME>
@@ -136,7 +137,7 @@ Note that all settings (such as 'log_level') affect both compilations.
   missing and added resources. Does not affect if catalogs are considered equal or
   compliant. The default is `--no-verbose-diff`.
 
-* --version:
+* --version
   Prints the puppet version number and exit.
 
 * --view <REPORT>
@@ -144,8 +145,8 @@ Note that all settings (such as 'log_level') affect both compilations.
 
   | REPORT          | Output
   | --------------- | ----------------------------------------------------------------------
-  | summary         | A single node diff summary, or the status per node  
-  | diff            | The catalog diff for one node in json format  
+  | summary         | A single node diff summary, or the status per node
+  | diff            | The catalog diff for one node in json format
   | baseline        | The baseline catalog for one node in json
   | preview         | The preview catalog for one node in json
   | baseline-log    | The baseline log for one node in json
@@ -175,13 +176,18 @@ Note that all settings (such as 'log_level') affect both compilations.
   commands that further process the output.
 
   The 'overview-json' is "all the data" and it is used as the basis for the 'overview' report.
-  The fact that it contains "all the data" means it can be used to produce other views of the 
+  The fact that it contains "all the data" means it can be used to produce other views of the
   results across a set of nodes without having to load and interpret the output for each node
   from the file system.
-  It is marked as experimental, and its schema is not documented in this version of catalog preview 
+  It is marked as experimental, and its schema is not documented in this version of catalog preview
   as it may need adjustments in minor version updates. The intent is to document this in a
   subsequent release and that this report can be piped to custom commands, or to visualizers
   that can slice and dice the information.
+
+* --\[no-\]report-all
+  Controls if the 'overview' report will contain a list of nodes that is limited to the
+  ten nodes with the highest number of issues or if all nodes are included in the list. The default
+  is to only include the top ten nodes. This option can only be used together with with '--view overview'.
 
 * <NODE-NAME>+
   This specifies for which node the preview should produce output. The node must

--- a/spec/unit/overview_report_spec.rb
+++ b/spec/unit/overview_report_spec.rb
@@ -16,16 +16,26 @@ module PuppetX::Puppetlabs::Migration
 
         it 'can produce a hash' do
           hash = report.to_hash
-          expect(hash).to include(:stats, :baseline, :top_ten, :changes)
+          expect(hash).to include(:stats, :baseline, :all_nodes, :changes)
           expect(hash[:changes]).to include(:resource_type_changes, :edge_changes)
         end
 
-        it 'can produce a text' do
-          text = report.to_s
+        it 'can produce a text with top ten nodes' do
+          text = report.to_text(true)
           expect(text).to match(/^Stats$/)
           expect(text).to match(/^Baseline Errors \(by manifest\)$/)
           expect(text).to match(/^Baseline Errors \(by issue\)$/)
           expect(text).to match(/^Top ten nodes with most issues$/)
+          expect(text).to match(/^Changes per Resource Type$/)
+          expect(text).to match(/^Changes of Edges$/)
+        end
+
+        it 'can produce a text with all nodes' do
+          text = report.to_text(false)
+          expect(text).to match(/^Stats$/)
+          expect(text).to match(/^Baseline Errors \(by manifest\)$/)
+          expect(text).to match(/^Baseline Errors \(by issue\)$/)
+          expect(text).to match(/^All nodes$/)
           expect(text).to match(/^Changes per Resource Type$/)
           expect(text).to match(/^Changes of Edges$/)
         end


### PR DESCRIPTION
This commit adds the flag --[no-]report-all. If true, the human
readable overview report (obtained with --view overview) will include
a list of all nodes, as opposed to a list limited to the top ten nodes
with most issues.

The default setting for the flag is `false`, i.e. only the top ten nodes
will be reported.