### PR TITLE
(PRE-95) Add flag to skip/not skip nodes that are inactive

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,9 @@ For details about the migration specific warnings, see the DIAGNOSTICS section i
 
 This specifies for which node the preview should produce output. The node must have previously requested a catalog from the master to make its facts available. It is possible to give multiple node names on the command line, via a file, or piping them to the command by using the [`--nodes`](#--nodes) option.
 
+#####`--[no-]skip-inactive-nodes`
+Skip nodes that are given and found to be inactive. This flag only have effect in a configuration that is using PuppetDB. The default is `--skip-inactive-nodes`.
+
 #####`--preview-outputdir 'DIR'`
 
 Defines the directory to which output is produced. This is a Puppet setting that can be overridden on the command line (defaults to `$vardir/preview`).

--- a/lib/puppet/application/preview.rb
+++ b/lib/puppet/application/preview.rb
@@ -428,7 +428,7 @@ class Puppet::Application::Preview < Puppet::Application
 
     # If the face action 'node status' exists (provided by PuppetDB), then purge inactive and non existent nodes from the list
     node_face = Puppet::Interface[:node, :current]
-    if node_face.respond_to?(:status)
+    if using_puppetdb? && node_face.respond_to?(:status)
       skip_inactive = options.include?(:skip_inactive_nodes) ? options[:skip_inactive_nodes] : true
       given_names = given_names.select do |node_name|
         status = node_face.status(node_name)[0]
@@ -778,6 +778,10 @@ Output:
     Puppet::FileSystem.open(filename, nil, 'ab') { |of| of.write(endtext) }
   end
 
+  def using_puppetdb?
+    Puppet::Node::Facts.indirection.terminus_class.to_s == 'puppetdb'
+  end
+
   def configure_indirector_routes
     # Same implementation as the base Application class, except this loads
     # routes configured for the "master" application in order to conform with
@@ -799,7 +803,7 @@ Output:
     #
     # So, if PuppetDB is in use, we swap in a copy of the 2.x terminus which
     # uses the v4 API which returns properly structured and typed facts.
-    if Puppet::Node::Facts.indirection.terminus_class.to_s == 'puppetdb'
+    if using_puppetdb?
       # Versions prior to pdb 3 uses the v3 REST API, but there is not easy
       # way to figure out which version is in use that works for both old
       # and new versions. The method 'Puppet::Util::Puppetdb.url_path' has

--- a/lib/puppet/application/preview.rb
+++ b/lib/puppet/application/preview.rb
@@ -3,6 +3,7 @@ require 'puppet/file_system'
 require 'puppet_x/puppetlabs/preview'
 require 'puppet/util/colors'
 require 'puppet/pops'
+require 'puppet/interface'
 
 class Puppet::Application::Preview < Puppet::Application
 
@@ -84,6 +85,8 @@ class Puppet::Application::Preview < Puppet::Application
   option('--[no-]diff-array-value')
 
   option('--[no-]report-all')
+
+  option('--[no-]skip-inactive-nodes')
 
   option('--trusted') do |_|
     options[:trusted] = true
@@ -201,9 +204,7 @@ class Puppet::Application::Preview < Puppet::Application
       end
       @exit_code = 0
     else
-      if options[:nodes].nil? || options[:nodes].empty? && !options[:last]
-        raise UsageError, 'No node(s) given to perform preview compilation for'
-      end
+      init_node_names_for_compile unless options[:last]
 
       if node_names.size > 1 && [:diff, :baseline, :preview, :baseline_log, :preview_log].include?(options[:view])
         raise UsageError, "The --view option '#{options[:view].to_s.gsub(/_/, '-')}' is not supported for multiple nodes"
@@ -255,7 +256,7 @@ class Puppet::Application::Preview < Puppet::Application
   end
 
   def assert_and_set_exit_code
-    nodes = @overview.of_class(OverviewModel::Node)
+    nodes = @overview.nil? ? [] : @overview.of_class(OverviewModel::Node)
     @exit_code =  nodes.reduce(0) do |result, node|
       exit_code = node.exit_code
       break exit_code if exit_code == BASELINE_FAILED
@@ -419,6 +420,32 @@ class Puppet::Application::Preview < Puppet::Application
     output_dir = Puppet[:preview_outputdir]
     node_names.each { |node| FileUtils.remove_entry_secure(File.join(output_dir, node)) }
     @exit_code = 0
+  end
+
+  def init_node_names_for_compile
+    given_names = options[:nodes]
+    raise UsageError, 'No node(s) given to perform preview compilation for' if given_names.nil? || given_names.empty?
+
+    # If the face action 'node status' exists (provided by PuppetDB), then purge inactive and non existent nodes from the list
+    node_face = Puppet::Interface[:node, :current]
+    if node_face.respond_to?(:status)
+      skip_inactive = options.include?(:skip_inactive_nodes) ? options[:skip_inactive_nodes] : true
+      given_names = given_names.select do |node_name|
+        status = node_face.status(node_name)[0]
+        if status.nil? || status.size < 1
+          # An error has been output by the status action
+          false
+        elsif skip_inactive && !status['deactivated'].nil?
+          # Notice unless JSON output is expected.
+          Puppet.notice("Skipping inactive node '#{node_name}'") unless options[:view] == :overview_json
+          false
+        else
+          true
+        end
+      end
+      raise UsageError, 'No compilation can be performed since none of the given node(s) are active' if given_names.empty?
+    end
+    @node_names = given_names
   end
 
   def node_names
@@ -702,6 +729,7 @@ Output:
   end
 
   def display_status
+    return if @overview.nil?
 
     node = @overview.of_class(OverviewModel::Node)[0]
     out = output_stream

--- a/lib/puppet_x/puppetlabs/preview/api/documentation/preview-help.md
+++ b/lib/puppet_x/puppetlabs/preview/api/documentation/preview-help.md
@@ -114,6 +114,10 @@ Note that all settings (such as 'log_level') affect both compilations.
   This may be combined with additional nodes given on the command line. Duplicate entries (in given
   file, or on command line) are skipped.
 
+* --\[no-\]skip-inactive-nodes
+  Skip nodes that are given and found to be inactive. This flag only have effect in a configuration that
+  is using PuppetDB. The default is `--skip-inactive-nodes`.
+
 * --preview-environment <ENV-NAME> | --pe <ENV-NAME>
   Makes the preview compilation take place in the given <ENV-NAME>.
   Uses facts obtained from the configured facts terminus to compile the catalog.


### PR DESCRIPTION
Prior to this commit, a compile was attempted for all nodes given on
the command line. Now, a check is instead made to see if the 'status'
action exists on the 'node' face. This action is provided by PuppetDB
and if it exists, it is used to obtain the status for each of the nodes.

Nodes that are found inactive will not be compiled unless the new option
--no-skip-inactive-nodes is given. Nodes that are not found at all will
not be compiled and result in an error printout. The preview command
will then continue with the next node.