### PR TITLE
(PRE-105) Ensure that issues and issue locations are reported uniquely

### DIFF
--- a/lib/puppet_x/puppetlabs/migration/overview_model/report.rb
+++ b/lib/puppet_x/puppetlabs/migration/overview_model/report.rb
@@ -231,7 +231,7 @@ module OverviewModel
           error[:pos] = location.pos unless location.pos.nil?
         end
         manifest_errors = (manifest_hash[:errors] ||= [])
-        manifest_errors << error
+        manifest_errors << error unless manifest_errors.include?(error)
       end
       errors.map { |_, m| m[:nodes] = m[:nodes].to_a; m }.sort { |a, b| b[:nodes].size <=> a[:nodes].size }
     end
@@ -290,6 +290,7 @@ module OverviewModel
           end
         end
       end
+      issues.each_value { |issue| issue[:manifests].each_value { |positions| positions.uniq! } }
       issues.values.sort { |a, b| b[:count] <=> a[:count] }
     end
 

--- a/spec/integration/preview_spec.rb
+++ b/spec/integration/preview_spec.rb
@@ -394,7 +394,7 @@ EOS
       expect(report['stats']['failures']['preview']['total']).to eq(node_names_all.length)
       expect(report['preview']).to be_a(Hash)
       expect(report['preview']['compilation_errors']).to be_an(Array)
-      expect(report['preview']['compilation_errors'][0]['errors'].size).to be(node_names_all.length)
+      expect(report['preview']['compilation_errors'][0]['errors'].size).to eq(1) # the error is exactly the same in all nodes. Duplicates are eliminated
     end
   end
 


### PR DESCRIPTION
Before this commit, issues reported under 'compilation_errors' and
issue locations reported under 'error_count_by_issue_code' and
'warning_count_by_issue_code' were duplicated <n> times where <n>
stands for the number of nodes that had the error/warning. This
commit ensures that such duplicates are eliminated.