### PR TITLE
(PRE-103) Improve sorting and information in "all nodes" list.

### DIFF
--- a/spec/unit/overview_report_spec.rb
+++ b/spec/unit/overview_report_spec.rb
@@ -7,6 +7,15 @@ module PuppetX::Puppetlabs::Migration
     describe Report do
       let!(:conflicting_delta) { CatalogDeltaModel::CatalogDelta.from_hash(load_catalog_delta('conflicting-delta.json')) }
       let!(:assignment_failed_log) { load_compile_log('assignment_failed.json') }
+      let!(:nodes_table) do
+        <<-NODES_TABLE
+        node name        errors  warnings   diffs
+  --------------------- -------- -------- --------
+  failed.example.com           1        0        0
+  different.example.com        1        0        0
+  different.example.com        0        0        3
+        NODES_TABLE
+      end
 
       context 'when reporting' do
         let!(:now) { Time.now.iso8601(9) }
@@ -45,9 +54,9 @@ module PuppetX::Puppetlabs::Migration
           expect(text).to match(/^Stats$/)
           expect(text).to match(/^Baseline Errors \(by manifest\)$/)
           expect(text).to match(/^Baseline Errors \(by issue\)$/)
-          expect(text).to match(/^Top ten nodes with most issues$/)
           expect(text).to match(/^Changes per Resource Type$/)
           expect(text).to match(/^Changes of Edges$/)
+          expect(text).to end_with("Top ten nodes with most issues\n" + nodes_table)
         end
 
         it 'can produce a text with all nodes' do
@@ -55,9 +64,8 @@ module PuppetX::Puppetlabs::Migration
           expect(text).to match(/^Stats$/)
           expect(text).to match(/^Baseline Errors \(by manifest\)$/)
           expect(text).to match(/^Baseline Errors \(by issue\)$/)
-          expect(text).to match(/^All nodes$/)
           expect(text).to match(/^Changes per Resource Type$/)
-          expect(text).to match(/^Changes of Edges$/)
+          expect(text).to end_with("All nodes\n" + nodes_table)
         end
       end
     end


### PR DESCRIPTION
This commit replaces the simple "issue count" in the node list
with five counters for errors, warnings, added resources, removed
resources, and changed resources. It also changes the sorting of the
list to a descending sort based on errors, warnings, and the sum
of all resource counters.

The output produced by `--view overview` now outputs a table with node
name and counters for errors, warnings, and the sum of all resource
counters instead of just the node name and an issue counter.