### PR TITLE
(PRE-106) test harness for catalog preview acceptance tests is broken

### DIFF
--- a/spec/integration/preview_spec.rb
+++ b/spec/integration/preview_spec.rb
@@ -282,7 +282,7 @@ EOS
   it 'should error if using an unsupported --view type with multiple nodes' do
     view_types = %w{baseline preview diff baseline-log preview-log}
     view_types.each do |view_type|
-      on master, puppet("preview --view #{view_type} one two shoe"),
+      on master, puppet("preview --view #{view_type} nonesuch andanother file_node1"),
         {:acceptable_exit_codes => [1]} do |r|
         expect(r.stderr).to match(/Error:.*#{view_type}.*multiple nodes/)
       end

--- a/spec/spec_helper_integration.rb
+++ b/spec/spec_helper_integration.rb
@@ -398,5 +398,17 @@ HERE
     # ensure non-root users can access the module in PE 3x:
     on master, "mkdir -p /usr/share/puppet/modules && ln -s #{target_module_path}/preview /usr/share/puppet/modules", :accept_all_exit_codes => true
 
+    step 'add node names to puppetdb that are used in the tests' do
+      node_names_file = ['file_node1', 'file_node2']
+      node_names_cli  = ['nonesuch', 'andanother']
+      node_names_all  = node_names_cli + node_names_file
+      curl_headers = "--silent --show-error -H 'Content-Type:application/json'   -H 'Accept:application/json'"
+
+      node_names_all.each do |node_name|
+        curl_payload = "{\"certname\":\"#{node_name}\",\"environment\":\"DEV\",\"values\":{\"myfact\":\"myvalue\"},\"producer_timestamp\":\"2015-01-01\"}"
+        on master, "curl -X POST #{curl_headers} -d '#{curl_payload}' 'http://localhost:8080/pdb/cmd/v1?command=replace_facts&version=4&certname=#{node_name}'"
+      end
+    end
+
   end
 end


### PR DESCRIPTION
(PRE-106) remove node names not in puppetdb from tests

(PRE-106) add nodes to puppetdb for compilation

* catalog-preview now looks up nodes in puppetdb to determine if they are active or should be skipped
* "register" node names used in tests with puppetdb by adding facts for them
