### PR TITLE
(PRE-107) Ensure that the order is consistent when reporting nodes

### DIFF
--- a/lib/puppet_x/puppetlabs/migration/overview_model/report.rb
+++ b/lib/puppet_x/puppetlabs/migration/overview_model/report.rb
@@ -184,6 +184,7 @@ module OverviewModel
         if cmp == 0
           cmp = b[:warning_count] <=> a[:warning_count]
           cmp = diff_count(b) <=> diff_count(a) if cmp == 0
+          cmp = a[:name] <=> b[:name] if cmp == 0
         end
         cmp
       end

--- a/spec/unit/overview_report_spec.rb
+++ b/spec/unit/overview_report_spec.rb
@@ -11,8 +11,8 @@ module PuppetX::Puppetlabs::Migration
         <<-NODES_TABLE
         node name        errors  warnings   diffs
   --------------------- -------- -------- --------
-  failed.example.com           1        0        0
   different.example.com        1        0        0
+  failed.example.com           1        0        0
   different.example.com        0        0        3
         NODES_TABLE
       end

--- a/spec/unit/preview_spec.rb
+++ b/spec/unit/preview_spec.rb
@@ -258,7 +258,7 @@ Catalogs for 'compliant.example.com' are not equal but compliant.
     end
   end
 
-  context 'when running with --migrate' do
+  context 'when running with --migrate', :if => Puppet.version =~ /^3\./ do
     let(:preview) {
       preview = Puppet::Application[:preview]
       preview.options[:nodes] = ['default']
@@ -277,7 +277,7 @@ Catalogs for 'compliant.example.com' are not equal but compliant.
       end
     end
 
-    it 'can produce a diff between two environments', :if => Puppet.version =~ /^3\./ do
+    it 'can produce a diff between two environments' do
       options[:preview_environment] = 'env4x'
       options[:migrate] = '3.8/4.0'
       options[:view] = :diff
@@ -289,7 +289,7 @@ Catalogs for 'compliant.example.com' are not equal but compliant.
       expect(json_diff['conflicting_attribute_count']).to eql(2)
     end
 
-    it 'can produce a diff by compiling the same environment twice with different parsers', :if => Puppet.version =~ /^3\./ do
+    it 'can produce a diff by compiling the same environment twice with different parsers' do
       options[:migrate] = '3.8/4.0'
       options[:view] = :diff
 


### PR DESCRIPTION
Before this commit, the order of reported nodes was undefined if
the nodes had the same number of errors, warnings, and diffs. This
commit adds the node name the set ordering (with lowest prio).