### PR TITLE
(PRE-100) Fix failing test for 'No osfamily fact found'

### DIFF
--- a/lib/puppet/indirector/catalog/diff_compiler.rb
+++ b/lib/puppet/indirector/catalog/diff_compiler.rb
@@ -188,13 +188,15 @@ class Puppet::Resource::Catalog::DiffCompiler < Puppet::Indirector::Code
 
             # Do the compilation
             begin
-              baseline_catalog = Puppet::Parser::Compiler.compile(node) do |catalog|
-                if node.facts.nil? || node.facts.values.nil? || node.facts.values['osfamily'].nil?
-                  # Node does not have a valid factset.
-                  raise PuppetX::Puppetlabs::Preview::GeneralError, "Facts seems to be missing. No 'osfamily' fact found for node '#{name}'"
-                end
-                catalog
+              baseline_catalog = Puppet::Parser::Compiler.compile(node)
+              if node.facts.nil? || node.facts.values.nil? || node.facts.values['osfamily'].nil?
+                # Node does not have a valid factset.
+                raise PuppetX::Puppetlabs::Preview::GeneralError, "Facts seems to be missing. No 'osfamily' fact found for node '#{name}'"
               end
+            rescue Puppet::Error
+              # Already logged
+              raise PuppetX::Puppetlabs::Preview::BaselineCompileError, 'Error while compiling the baseline catalog'
+
             rescue StandardError => e
               # Log it (ends up in baseline_log)
               Puppet.err(e.to_s)
@@ -249,14 +251,13 @@ class Puppet::Resource::Catalog::DiffCompiler < Puppet::Indirector::Code
             end
 
             begin
-              preview_catalog = Puppet::Parser::Compiler.compile(node) do |catalog|
-                if node.facts.nil? || node.facts.values.nil? || node.facts.values['osfamily'].nil?
-                  # Node does not have a valid factset.
-                  raise PuppetX::Puppetlabs::Preview::GeneralError, "Facts seems to be missing. No 'osfamily' fact found for node '#{name}'"
-                end
-                catalog
+              preview_catalog = Puppet::Parser::Compiler.compile(node)
+               if node.facts.nil? || node.facts.values.nil? || node.facts.values['osfamily'].nil?
+                # Node does not have a valid factset.
+                raise PuppetX::Puppetlabs::Preview::GeneralError, "Facts seems to be missing. No 'osfamily' fact found for node '#{name}'"
               end
             rescue Puppet::Error
+              # Already logged
               raise PuppetX::Puppetlabs::Preview::PreviewCompileError, 'Error while compiling the preview catalog'
 
             rescue StandardError => e

--- a/spec/unit/preview_spec.rb
+++ b/spec/unit/preview_spec.rb
@@ -304,11 +304,12 @@ Catalogs for 'compliant.example.com' are not equal but compliant.
     it 'fails when no valid facts exist for a node' do
       options[:preview_environment] = 'env4x'
       options[:migrate] = '3.8/4.0'
-      options[:view] = :diff
-      options[:output_stream] = StringIO.new
+      options[:view] = :overview
+      output_stream = StringIO.new
+      options[:output_stream] = output_stream
       Puppet::Node::Facts.any_instance.expects(:values).at_least_once.returns({})
-      expect{ preview.main }.to raise_error(PuppetX::Puppetlabs::Preview::GeneralError,
-        "Facts seems to be missing. No 'osfamily' fact found for node 'diff_compiler'")
+      expect(preview.main).to eq(PuppetX::Puppetlabs::Migration::BASELINE_FAILED)
+      expect(output_stream.string).to match(/Facts seems to be missing. No 'osfamily' fact found for node 'diff_compiler'/)
     end
   end
 end


### PR DESCRIPTION
The code assumed that the compile call would accept a block. That is
only true when using the call on a compiler instance, not on the class.
The subsequent test only "worked" on 4.x (since it was disabled there).

This commit ensures that the check for empty factset is in the correct
place and that the test works when using Puppet 3.8.x