### PR TITLE
(PRE-95) remove skip-inactive-nodes docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,9 +461,6 @@ For details about the migration specific warnings, see the DIAGNOSTICS section i
 
 This specifies for which node the preview should produce output. The node must have previously requested a catalog from the master to make its facts available. It is possible to give multiple node names on the command line, via a file, or piping them to the command by using the [`--nodes`](#--nodes) option.
 
-#####`--[no-]skip-inactive-nodes`
-Skip nodes that are given and found to be inactive. This flag only have effect in a configuration that is using PuppetDB. The default is `--skip-inactive-nodes`.
-
 #####`--preview-outputdir 'DIR'`
 
 Defines the directory to which output is produced. This is a Puppet setting that can be overridden on the command line (defaults to `$vardir/preview`).

--- a/lib/puppet_x/puppetlabs/preview/api/documentation/preview-help.md
+++ b/lib/puppet_x/puppetlabs/preview/api/documentation/preview-help.md
@@ -114,10 +114,6 @@ Note that all settings (such as 'log_level') affect both compilations.
   This may be combined with additional nodes given on the command line. Duplicate entries (in given
   file, or on command line) are skipped.
 
-* --\[no-\]skip-inactive-nodes
-  Skip nodes that are given and found to be inactive. This flag only have effect in a configuration that
-  is using PuppetDB. The default is `--skip-inactive-nodes`.
-
 * --preview-environment <ENV-NAME> | --pe <ENV-NAME>
   Makes the preview compilation take place in the given <ENV-NAME>.
   Uses facts obtained from the configured facts terminus to compile the catalog.


### PR DESCRIPTION
The `--no-skip-inactive-nodes` flag is not yet functional and the
`--skip-inactive-nodes` behavior will be the default. So, the switch
currently does not change the behavior of catalog preview.

This commit removes the documentation for the switch from the README
and the `help` output. This documentation can be reinstated when the
`--no-skip-inactive-nodes` flag works.