### PR TITLE
(PRE-104) Fix acceptance baseline

### DIFF
--- a/spec/integration/preview_spec.rb
+++ b/spec/integration/preview_spec.rb
@@ -581,40 +581,43 @@ EOS
   end
 
   context 'when using --skip-inactive-nodes' do
-    env_path = File.join(testdir_simple, 'environments')
-    # create active and inactive node
-    test_node_inactive = "pl-inactive-node-#{rand(999999).to_i}"
-    test_node_active = "pl-active-node-#{rand(999999).to_i}"
-    test_nodes = [ test_node_inactive, test_node_active ]
-    node_names_file = "#{testdir_simple}/skip-inactive-nodes#{rand(999999).to_i}"
-    create_remote_file(master, node_names_file, test_nodes.join(' '))
-    test_nodes.each do |test_node|
-      add_node_to_puppetdb(test_node, 'production')
+    before(:all) do
+      puppetdb_ver = puppet_version =~ /3\./ ? '2.3.5' : 'latest'
+      @env_path = File.join(testdir_simple, 'environments')
+      # create active and inactive node
+      @test_node_inactive = "pl-inactive-node-#{rand(999999).to_i}"
+      @test_node_active = "pl-active-node-#{rand(999999).to_i}"
+      test_nodes = [ @test_node_inactive, @test_node_active ]
+      @node_names_file = "#{testdir_simple}/skip-inactive-nodes#{rand(999999).to_i}"
+      create_remote_file(master, @node_names_file, test_nodes.join(' '))
+      test_nodes.each do |test_node|
+        add_node_to_puppetdb(test_node, 'test', puppetdb_ver)
+      end
+      on master, puppet('node', 'deactivate', @test_node_inactive)
     end
-    on master, puppet('node', 'deactivate', test_node_inactive)
 
     it 'should skip inactive nodes by default' do
-      result = on(master, puppet("preview --preview-environment test --environmentpath #{env_path} --view baseline --nodes #{node_names_file}"),
+      result = on(master, puppet("preview --preview-environment test --environmentpath #{@env_path} --view none --nodes #{@node_names_file}"),
         :acceptable_exit_codes => [0])
-      assert_match(/Skipping inactive node.*#{test_node_inactive}/,result.stdout,'preview output from failed preview did not match expected')
+      assert_match(/Skipping inactive node.*#{@test_node_inactive}/,result.stdout,'preview output from failed preview did not match expected')
     end
 
     it 'should skip inactive nodes when using --skip-inactive-nodes flag' do
-      result = on(master, puppet("preview --preview-environment test --environmentpath #{env_path} --view baseline --nodes #{node_names_file}"),
+      result = on(master, puppet("preview --preview-environment test --environmentpath #{@env_path} --view none --nodes #{@node_names_file}"),
         :acceptable_exit_codes => [0])
-      assert_match(/Skipping inactive node.*#{test_node_inactive}/,result.stdout,'preview output from failed preview did not match expected')
+      assert_match(/Skipping inactive node.*#{@test_node_inactive}/,result.stdout,'preview output from failed preview did not match expected')
     end
 
     it 'should error when skip inactive nodes results in no active nodes' do
-      result = on(master, puppet("preview --skip-inactive-nodes --preview-environment test --environmentpath #{env_path} --view baseline #{test_node_inactive}"),
+      result = on(master, puppet("preview --skip-inactive-nodes --preview-environment test --environmentpath #{@env_path} --view baseline #{@test_node_inactive}"),
         :acceptable_exit_codes => [1])
       assert_match(/none of the given node\(s\) are active/,result.stderr,'preview output from failed preview did not match expected')
     end
 
     it 'should include inactive nodes when using --no-skip-inactive-nodes' do
       pending('PRE-115 - facts are not retrieved for inactive nodes')
-      result = on(master, puppet("preview --no-skip-inactive-nodes --preview-environment test --environmentpath #{env_path} --view baseline #{test_node_inactive}"))
-      assert_match(/"name": "#{test_node_inactive}"/,result.stdout,'preview output from failed preview did not match expected')
+      result = on(master, puppet("preview --no-skip-inactive-nodes --preview-environment test --environmentpath #{@env_path} --view baseline #{@test_node_inactive}"))
+      assert_match(/"name": "#{@test_node_inactive}"/,result.stdout,'preview output from failed preview did not match expected')
     end
   end
 


### PR DESCRIPTION
This commit updates the `skip-inactive-nodes` acceptance tests.

Some of the tests were attempting to use the `--view baseline` flag
when providing a node file with multiple nodes. This has been changed
to use the `--view none` flag.

The `puppetdb-version` was not being set in this test block to
make sure that the properly configured API was being used. This value
is now being set based on the `puppet-version`.

The set up steps in the context did not seem to execute consistently
prior to the individual tests. These have been wrapped in an rspec
`before(:all)` block to ensure that the setup steps are completed
before the tests commence.