### PR TITLE
(PRE-122) Inactive nodes not skipped by default

### DIFF
--- a/lib/puppet/application/preview.rb
+++ b/lib/puppet/application/preview.rb
@@ -779,7 +779,8 @@ Output:
   end
 
   def using_puppetdb?
-    Puppet::Node::Facts.indirection.terminus_class.to_s == 'puppetdb'
+    # Need to cache this since the terminus is subsequently replaced
+    @using_puppetdb ||= Puppet::Node::Facts.indirection.terminus_class.to_s == 'puppetdb'
   end
 
   def configure_indirector_routes

--- a/spec/integration/preview_spec.rb
+++ b/spec/integration/preview_spec.rb
@@ -597,21 +597,18 @@ EOS
     end
 
     it 'should skip inactive nodes by default' do
-      pending('PRE-122 - --skip-inactive-nodes attempts to retrieve facts for inactive nodes')
       result = on(master, puppet("preview --preview-environment test --environmentpath #{@env_path} --view none --nodes #{@node_names_file}"),
         :acceptable_exit_codes => [0])
       assert_match(/Skipping inactive node.*#{@test_node_inactive}/,result.stdout,'preview output from failed preview did not match expected')
     end
 
     it 'should skip inactive nodes when using --skip-inactive-nodes flag' do
-      pending('PRE-122 - --skip-inactive-nodes attempts to retrieve facts for inactive nodes')
       result = on(master, puppet("preview --preview-environment test --environmentpath #{@env_path} --view none --nodes #{@node_names_file}"),
         :acceptable_exit_codes => [0])
       assert_match(/Skipping inactive node.*#{@test_node_inactive}/,result.stdout,'preview output from failed preview did not match expected')
     end
 
     it 'should error when skip inactive nodes results in no active nodes' do
-      pending('PRE-122 - --skip-inactive-nodes attempts to retrieve facts for inactive nodes')
       result = on(master, puppet("preview --skip-inactive-nodes --preview-environment test --environmentpath #{@env_path} --view baseline #{@test_node_inactive}"),
         :acceptable_exit_codes => [1])
       assert_match(/none of the given node\(s\) are active/,result.stderr,'preview output from failed preview did not match expected')


### PR DESCRIPTION
This commit ensures that the method Preview#using_puppetdb? continues
to return `true` for the duration of a run. This was not the case
earlier since that method tested for the name of the Facts terminus and
when it was found to be 'puppetdb', that termnus was replaced with
the tailored 'diff_puppetdb' terminus. Subsequent calls to
#using_puppetdb? would hence return false. That in turn, broke the
test for if a node was active or deactivated.