### PR TITLE
(PRE-122) added --skip-inactive-nodes tag to a test

### DIFF
--- a/spec/integration/preview_spec.rb
+++ b/spec/integration/preview_spec.rb
@@ -603,7 +603,7 @@ EOS
     end
 
     it 'should skip inactive nodes when using --skip-inactive-nodes flag' do
-      result = on(master, puppet("preview --preview-environment test --environmentpath #{@env_path} --view none --nodes #{@node_names_file}"),
+      result = on(master, puppet("preview --skip-inactive-nodes --preview-environment test --environmentpath #{@env_path} --view none --nodes #{@node_names_file}"),
         :acceptable_exit_codes => [0])
       assert_match(/Skipping inactive node.*#{@test_node_inactive}/,result.stdout,'preview output from failed preview did not match expected')
     end


### PR DESCRIPTION
test case https://github.com/puppetlabs/puppetlabs-catalog_preview/blob/master/spec/integration/preview_spec.rb#L605-L609 does not have --skip-inactive-nodes flag.

This PR adds the flag to the test case