### PR TITLE
(PRE-123) Replace require_relative with require

### DIFF
--- a/lib/puppet_x/puppetlabs/migration/catalog_delta_model.rb
+++ b/lib/puppet_x/puppetlabs/migration/catalog_delta_model.rb
@@ -1,4 +1,4 @@
-require_relative 'model_object'
+require 'puppet_x/puppetlabs/migration/model_object'
 
 module PuppetX::Puppetlabs::Migration
 module CatalogDeltaModel

--- a/lib/puppet_x/puppetlabs/migration/overview_model.rb
+++ b/lib/puppet_x/puppetlabs/migration/overview_model.rb
@@ -1,7 +1,7 @@
-require_relative 'model_object'
-require_relative 'overview_model/query'
-require_relative 'overview_model/factory'
-require_relative 'overview_model/report'
+require 'puppet_x/puppetlabs/migration/model_object'
+require 'puppet_x/puppetlabs/migration/overview_model/query'
+require 'puppet_x/puppetlabs/migration/overview_model/factory'
+require 'puppet_x/puppetlabs/migration/overview_model/report'
 
 module PuppetX::Puppetlabs::Migration
   module OverviewModel


### PR DESCRIPTION
require_relative was introduced in Ruby 1.9. Catalog-preview must run
with 1.8.7.