### PR TITLE
(PRE-125) fix ci failure

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,10 @@ group :development do
   gem 'guard-rake'
   gem 'rubocop', '0.41.2' if RUBY_VERSION < '2.0.0'
   gem 'rubocop' if RUBY_VERSION >= '2.0.0'
-  gem 'rubocop-rspec', '~> 1.6' if RUBY_VERSION >= '2.3.0'
+  if RUBY_VERSION >= '2.3.0'
+    gem 'rubocop-rspec', '~> 1.6'
+    gem 'safe_yaml', '~> 1.0.4'
+  end
 end
 
 local_gemfile = "#{__FILE__}.local"


### PR DESCRIPTION
safe_yaml needs to be installed when testing puppet 4.6.1 with Ruby >= 2.3.0