### PR TITLE
(PRE-125) Add psych gem, enabled for Ruby >= 2.3.0 to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,10 @@ group :development, :unit_tests do
   # json_pure 2 dropped support for < ruby 2.0, so bind to json_pure 1.8
   # as long as this continues to be tested against 1.9.3
   gem 'json_pure', '~> 1.8',     :require => false
+  if RUBY_VERSION >= '2.3.0'
+    gem 'syck',  :require => false
+    gem 'safe_yaml', '~> 1.0.4'
+  end
 end
 
 group :development do


### PR DESCRIPTION
Before this commit, a `bundle exec rspec spec` would fail on
"uninitialized constant Syck" when running Ruby >= 2.3.0. This commit
adds the missing gem to the Gemfile conditionally.