### PR TITLE
(PRE-124) fix debian8 nodeset file

### DIFF
--- a/spec/integration/nodesets/debian8-64mda.yaml
+++ b/spec/integration/nodesets/debian8-64mda.yaml
@@ -13,6 +13,7 @@ HOSTS:
     - master
     - database
 CONFIG:
+  type: foss
   nfs_server: none
   consoleport: 443
   pooling_api: http://vmpooler.delivery.puppetlabs.net/


### PR DESCRIPTION
Apparently we are only setting the install-type in the nodeset files
because of the way beaker rspec runs.  Add the type so we don't try to
install PE when we don't want to.

[skip ci]