### PR TITLE
(PE-11711) Exclude puppet_enterprise modules from preview

### DIFF
--- a/lib/puppet/indirector/catalog/diff_compiler.rb
+++ b/lib/puppet/indirector/catalog/diff_compiler.rb
@@ -173,6 +173,8 @@ class Puppet::Resource::Catalog::DiffCompiler < Puppet::Indirector::Code
         end
         options[:back_channel][:baseline_environment] = node.environment
 
+        node.classes.delete_if {|k,v| k =~ /^(puppet_enterprise|pe_)/ }
+
         Puppet::Util::Profiler.profile(baseline_dest, [:diff_compiler, :compile_baseline, node.environment, node.name]) do
           Puppet.override({:current_environment => node.environment}, 'puppet-preview-baseline-compile') do
 


### PR DESCRIPTION
Prior to this commit, catalog preview would attempt to analyse
the modules that are included with Puppet Enterprise. Since
customers are not expected to fix problems in code that they
don't own, and since the diffs in these modules are known to
be "safe", differences in them should not clutter the output.

This commit excludes modules that begin with "puppet_enterprise"
or "pe_" from being included in the diff analysis.
