### PR TITLE
(maint) Tie rubocop versions to appropriate ruby versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,8 @@ group :development do
   gem 'travis-lint'
   gem 'puppet-blacksmith'
   gem 'guard-rake'
-  gem 'rubocop',                 :require => false
+  gem 'rubocop', '0.41.2' if RUBY_VERSION < '2.0.0'
+  gem 'rubocop' if RUBY_VERSION >= '2.0.0'
 end
 
 local_gemfile = "#{__FILE__}.local"


### PR DESCRIPTION
Prior to this commit, the Gemfile installed the latest version of
rubocop on all ruby versions. Because the latest version of
rubocop requires ruby 2.0 or greater, this was causing failures in
CI when spec tests were run against ruby 1.9.3.

In order to prevent this issue, only install the latest version
for ruby 2.0 or greater and for older versions of ruby use a
compatible release of rubocop.