### PR TITLE
(QENG-4946) Add beaker-hostgen and beaker-abs to Gemfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 sudo: false
-bundler_args: --without development
+bundler_args: --without development system_tests
 script:
   - "bundle exec $CHECK"
 notifications:

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,8 @@ group :system_tests do
   gem 'rake'
   gem 'beaker-rspec', *location_for(ENV['BEAKER_RSPEC_VERSION'] || '~> 6.0')
   gem 'beaker-pe', *location_for(ENV['BEAKER_PE_VERSION'] || '~> 1.1')
+  gem 'beaker-hostgenerator', *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'])
+  gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.2') 
   gem 'listen', '<3.1.0'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ group :system_tests do
   gem 'beaker-rspec', *location_for(ENV['BEAKER_RSPEC_VERSION'] || '~> 6.0')
   gem 'beaker-pe', *location_for(ENV['BEAKER_PE_VERSION'] || '~> 1.1')
   gem 'beaker-hostgenerator', *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'])
-  gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.2') 
+  gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.2')
   gem 'listen', '<3.1.0'
 end
 
@@ -53,7 +53,7 @@ if File.exists? local_gemfile
   eval(File.read(local_gemfile), binding)
 end
 
-user_gemfile = File.join(Dir.home,'.Gemfile')
+user_gemfile = File.join(File.expand_path("~"),'.Gemfile')
 if File.exists? user_gemfile
   eval(File.read(user_gemfile), binding)
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
+# attempt to resolve gem dependencies by ruby version
+ruby RUBY_VERSION
 
 def location_for(place, fake_version = nil)
   if place =~ /^(git[:@][^#]*)#(.*)/
@@ -10,41 +12,45 @@ def location_for(place, fake_version = nil)
   end
 end
 
+current_ruby_version = Gem::Version.new(RUBY_VERSION)
+ruby_1_9_3 = Gem::Version.new('1.9.3')
+ruby_2_1_5 = Gem::Version.new('2.1.5')
+ruby_2_1_8 = Gem::Version.new('2.1.8')
+
 group :system_tests do
-  gem 'rake'
-  gem 'beaker-rspec', *location_for(ENV['BEAKER_RSPEC_VERSION'] || '~> 6.0')
-  gem 'beaker-pe', *location_for(ENV['BEAKER_PE_VERSION'] || '~> 1.1')
-  gem 'beaker-hostgenerator', *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'])
-  gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.2')
-  gem 'listen', '<3.1.0'
+  gem 'rake',                    '~> 0'
+  gem 'beaker-rspec',            *location_for(ENV['BEAKER_RSPEC_VERSION'] || '<  6.0') if current_ruby_version <  ruby_2_1_8
+  gem 'beaker-rspec',            *location_for(ENV['BEAKER_RSPEC_VERSION'] || '~> 6.0') if current_ruby_version >= ruby_2_1_8
+  # even though we define ruby version above, we need to pin some gems
+  #   probably due to gems without `required_ruby_version` defined
+  gem 'beaker',                  *location_for(ENV['BEAKER_VERSION'] || '<  3.16') if current_ruby_version <  ruby_2_1_8
+  gem 'beaker',                  *location_for(ENV['BEAKER_VERSION'] || '~> 3.0')  if current_ruby_version >= ruby_2_1_8
+  gem 'beaker-pe',               *location_for(ENV['BEAKER_PE_VERSION'] || '~> 1.1')
+  gem 'beaker-hostgenerator',    *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || '~> 0')
+  gem "beaker-abs",              *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.2')
 end
 
 group :development, :unit_tests do
   gem 'puppetlabs_spec_helper',  :require => false
-  gem 'puppet', *location_for(ENV['PUPPET_LOCATION'] || ENV['PUPPET_VERSION'] || '~> 3.8.0')
+  gem 'puppet',                  *location_for(ENV['PUPPET_LOCATION'] || ENV['PUPPET_VERSION'] || '~> 3.8.0')
+  # puppet depends on hiera, which has an unbound dependency on json_pure
+  gem 'json_pure',               '< 2.0.2' if current_ruby_version <  ruby_2_1_5 # puppet deps or transitive deps
   gem 'rspec',                   :require => false
   gem 'rspec-core',              :require => false
   gem 'rspec-puppet',            :require => false
   gem 'mocha',                   :require => false
   gem 'json-schema',             :require => false
-  # puppet depends on hiera, which has an unbound dependency on json_pure
-  # json_pure 2 dropped support for < ruby 2.0, so bind to json_pure 1.8
-  # as long as this continues to be tested against 1.9.3
-  gem 'json_pure', '~> 1.8',     :require => false
 end
 
 group :development do
-  gem 'travis'
-  gem 'travis-lint'
-  gem 'puppet-blacksmith'
-  # required by puppet-blacksmith
-  gem 'rest-client', '~> 1.8.0' # for ruby 1.9 compatibility
-  gem 'guard-rake'
-  gem 'rubocop', '0.41.2' if RUBY_VERSION < '2.0.0'
-  gem 'rubocop' if RUBY_VERSION >= '2.0.0'
-  if RUBY_VERSION >= '2.3.0'
-    gem 'rubocop-rspec', '~> 1.6'
-    gem 'safe_yaml', '~> 1.0.4'
+  gem 'travis'                   if current_ruby_version >= ruby_1_9_3
+  gem 'travis-lint'              if current_ruby_version >= ruby_1_9_3
+  gem 'puppet-blacksmith'        if current_ruby_version >= ruby_1_9_3
+  gem 'guard-rake'               if current_ruby_version >= ruby_1_9_3
+  gem 'rubocop'                  if current_ruby_version >= ruby_1_9_3
+  if current_ruby_version >= Gem::Version.new('2.3.0')
+    gem 'rubocop-rspec',         '~> 1.6'
+    gem 'safe_yaml',             '~> 1.0.4'
   end
 end
 


### PR DESCRIPTION
    These gems are requirements for CI.Next. CI changes will follow
    in ci-job-configs 

   (maint) resolve bundled dependencies based upon RUBY_VERSION

    * attempt to use `ruby RUBY_VERSION` in the Gemfile to resolve
     transitive deps for us.  This only gets us so far. Some Gems do not
     have `require_ruby_version` defined in their gemspec nor Gemfile, so
     this method falls over at a certain point.
    * we pin the other gems where required.
    * we also attempt to pin beaker(-rspec) versions based upon required
     transitive deps so we'll have to pin fewer of those in the future.
     don't hold your breath.
    * the beatings will continue until morale improves (until we can stop
     testing against ruby 1.8.7)

    (maint) allow ruby 1.8.7 in Gemfile

    * Dir.home does not exist in ruby 1.8.7.  this should be os agnostic
    * remove spurious newline

closes #189