### PR TITLE
(MODULES-4205) Remove UTF-8 quotes from preview.rb

### DIFF
--- a/lib/puppet/application/preview.rb
+++ b/lib/puppet/application/preview.rb
@@ -111,7 +111,7 @@ class Puppet::Application::Preview < Puppet::Application
   end
 
   # Sets up the 'node_cache_terminus' default to use the Write Only Yaml terminus :write_only_yaml.
-  # If this is not wanted, the setting ´node_cache_terminus´ should be set to nil.
+  # If this is not wanted, the setting `node_cache_terminus` should be set to nil.
   # @see Puppet::Node::WriteOnlyYaml
   # @see #setup_node_cache
   # @see puppet issue 16753


### PR DESCRIPTION
This patch removes some UTF-8 smart-quotes from preview.rb and replaces them
with ASCII backquotes. This prevent issues with pluginsync where module code is sent to agents operating in strict ASCII locales.