### PR TITLE
(maint) Pin listen gem version to prevent CI failures

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ group :development do
   gem 'travis-lint'              if current_ruby_version >= ruby_1_9_3
   gem 'puppet-blacksmith'        if current_ruby_version >= ruby_1_9_3
   gem 'guard-rake'               if current_ruby_version >= ruby_1_9_3
+  gem 'listen',                   '~> 3.0.0'
   gem 'rubocop'                  if current_ruby_version >= ruby_1_9_3
   if current_ruby_version >= Gem::Version.new('2.3.0')
     gem 'rubocop-rspec',         '~> 1.6'


### PR DESCRIPTION
Prior to this commit the listen gem (which the listen-guard gem
depends on) was not pinned to a particular version. Since the
latest version of the gem requires a Ruby version greater than 2.2
it was causing unit tests to fail on older versions.

Pin the listen gem to an older version so we can run with older
Ruby versions.