### PR TITLE
(maint) Update Travis CI Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ script:
 notifications:
   email: false
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.0
+  - 2.1.9
+  - 2.3.1
+  - 2.4.0
 
 env:
   - "CHECK='rspec -fd -c spec/unit'"


### PR DESCRIPTION
Prior to this commit preview was running in Travis CI with three
Ruby versions that are all no longer supported by Puppet. Update
the .travis.yml file to use more current versions. Soon this will
be module sync'd and this file will be managed that way, but in
the mean time this will help unblock work for preview.